### PR TITLE
fix: various data:record bugs

### DIFF
--- a/packages/plugin-data/messages/record.get.json
+++ b/packages/plugin-data/messages/record.get.json
@@ -1,5 +1,5 @@
 {
-  "description": "displays a single record",
+  "description": "displays a single record\nSpecify an sObject type and either an ID or a list of <fieldName>=<value> pairs.\nThe format of a field-value pair is <fieldName>=<value>.\nEnclose all field-value pairs in one set of double quotation marks, delimited by spaces.\nEnclose values that contain spaces in single quotes.\n\nTo get data on API performance metrics, specify both --perflog and --json.",
   "sObjectType": "the type of the record you’re retrieving",
   "sObjectId": "the ID of the record you’re retrieving",
   "where": "a list of <fieldName>=<value> pairs to search for",

--- a/packages/plugin-data/src/commands/force/data/record/create.ts
+++ b/packages/plugin-data/src/commands/force/data/record/create.ts
@@ -54,11 +54,12 @@ export default class Create extends DataCommand {
     const result = this.normalize<RecordResult>(await sobject.insert(values));
     if (result.success) {
       this.ux.log(messages.getMessage('createSuccess', [result.id || 'unknown id']));
+      this.ux.stopSpinner();
     } else {
       const errors = this.collectErrorMessages(result);
       this.ux.error(messages.getMessage('createFailure', [errors]));
+      this.ux.stopSpinner('failed');
     }
-    this.ux.stopSpinner();
     return result;
   }
 }

--- a/packages/plugin-data/src/dataCommand.ts
+++ b/packages/plugin-data/src/dataCommand.ts
@@ -7,7 +7,7 @@
 
 import { SfdxCommand } from '@salesforce/command';
 import { Messages, SfdxError, Org } from '@salesforce/core';
-import { AnyJson, Dictionary } from '@salesforce/ts-types';
+import { AnyJson, Dictionary, get, Nullable } from '@salesforce/ts-types';
 import { BaseConnection, ErrorResult, Record, SObject } from 'jsforce';
 
 Messages.importMessagesDirectory(__dirname);
@@ -136,6 +136,19 @@ export abstract class DataCommand extends SfdxCommand {
     // get back a single RecordResult. Nevertheless, we ensure that it's a
     // single RecordResult to make Typescript happy
     return Array.isArray(results) ? results[0] : results;
+  }
+
+  protected logNestedObject(obj: object, indentation = 0): void {
+    const space = ' '.repeat(indentation);
+    Object.keys(obj).forEach((key) => {
+      const value = get(obj, key, null) as Nullable<string | object>;
+      if (!!value && typeof value === 'object') {
+        this.ux.log(`${space}${key}:`);
+        this.logNestedObject(value, indentation + 2);
+      } else {
+        this.ux.log(`${space}${key}: ${value as string}`);
+      }
+    });
   }
 
   /**

--- a/packages/plugin-data/test/commands/force/data/record/get.test.ts
+++ b/packages/plugin-data/test/commands/force/data/record/get.test.ts
@@ -89,6 +89,6 @@ describe('force:data:record:get', () => {
     .it('should throw an error if values provided to where flag are invalid', (ctx) => {
       const result = JSON.parse(ctx.stdout);
       expect(result.status).to.equal(1);
-      expect(result.message).to.equal('Malformed key=value pair for value: Name');
+      expect(result.name).to.equal('Malformed key=value pair for value: Name');
     });
 });


### PR DESCRIPTION
### What does this PR do?
Fixes the following:
  - Missing description for `force:data:record:get`
  - Show expected error message when `force:data:record:get --where` returns multiple records
  - Make human readable output for `force:data:record:get` consistent with output from the toolbelt version

### What issues does this PR fix or reference?
@W-8449664@