### PR TITLE
Moves the data tree commands, messages, APIs, and tests from salesfor…

### DIFF
--- a/packages/plugin-data/messages/exportApi.json
+++ b/packages/plugin-data/messages/exportApi.json
@@ -1,0 +1,8 @@
+{
+    "queryNotProvided": "Provide a SOQL query statement or file containing a SOQL statement.",
+    "soqlInvalid": "Invalid SOQL query: %s",
+    "soqlMalformed": "The provided SOQL is malformed: %s",
+    "soqlMalformedAction": "Check the SOQL syntax and try again.",
+    "dataExportRecordCount": "Processed %s records from query: %s",
+    "dataExportRecordCountWarning": "Query returned more than 200 records. Please run the command using the plan option instead.\n Record Count: %s \nQuery: %s"
+}

--- a/packages/plugin-data/messages/importApi.json
+++ b/packages/plugin-data/messages/importApi.json
@@ -1,0 +1,16 @@
+{
+    "dataFileNotProvided": "Provide a data plan or file(s).",
+    "dataFileNotFound": "Cannot find data file. Indicate a valid path: %s.",
+    "unknownContentType": "Unable to determine content type for file: %s.",
+    "dataFileUnsupported": "Content type: %s not supported.",
+    "dataFileEmpty": "Data file is empty: %s.",
+    "dataFileInvalidJson": "data file is invalid JSON: %s",
+    "dataFileNoRefId": "Found references in file, but no reference-id content found (%s). Was parent SObjects saved first?",
+    "tooManyFiles": "Specify either sobjecttreefiles or a plan, but not both.",
+    "dataImportFailed": "Import failed from file: %s. Results: %s.",
+    "dataPlanValidationError": "Data plan file %s did not validate against the schema.",
+    "dataPlanValidationErrorAction1": "Did you run the force:data:tree:export command with the --plan flag?",
+    "dataPlanValidationErrorAction2": "Make sure you are importing a plan file.",
+    "dataPlanValidationErrorAction3": "You can get help with the import plan schema by running $ sfdx force:data:tree:import --confighelp\n%s",
+    "FlsError": "We couldn't process your request because you don't have access to %s on %s. To learn more about field-level security, visit Tips and Hints for Page Layouts and Field-Level Security in our Developer Documentation."
+}

--- a/packages/plugin-data/messages/tree.export.json
+++ b/packages/plugin-data/messages/tree.export.json
@@ -1,0 +1,11 @@
+{
+  "description": "export data from an org\nExports data from an org into sObject tree format for use with the force:data:tree:import command.\nThe query for export can return a maximum of 2,000 records. For more information, see the REST API Developer Guide: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobject_tree.htm",
+  "query": "soql query, or filepath of file containing a soql query, to retrieve records",
+  "plan": "generate mulitple sobject tree files and a plan definition file for aggregated import",
+  "prefix": "prefix of generated files",
+  "outputdir": "directory to store files'",
+  "examples": [
+    "sfdx force:data:tree:export -q \"SELECT Id, Name, (SELECT Name, Address__c FROM Properties__r) FROM Broker__c\"",
+    "sfdx force:data:tree:export -q <path to file containing soql query> -x export-demo -d /tmp/sfdx-out -p"
+  ]
+}

--- a/packages/plugin-data/messages/tree.import.json
+++ b/packages/plugin-data/messages/tree.import.json
@@ -1,0 +1,13 @@
+{
+  "description": "import data into an org\nImports data into an org using the SObject Tree Save API.  This data can include master-detail relationships.\nTo generate JSON files for use with force:data:tree:import, run \"sfdx force:data:tree:export\".\nThe SObject Tree API supports requests that contain up to 200 records. For more information, see the REST API Developer Guide: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobject_tree.htm",
+  "sobjecttreefiles": "comma-delimited, ordered paths of json files containing collection of record trees to insert",
+  "plan": "path to plan to insert multiple data files that have master-detail relationships",
+  "contenttype": "if data file extension is not .json, provide content type (applies to all files)",
+  "confighelp": "display schema information for the --plan configuration file to stdout; if you use this option, all other options except --json are ignored",
+  "examples": [
+    "sfdx force:data:tree:import -f Contact.json,Account.json -u me@my.org",
+    "sfdx force:data:tree:import -p Account-Contact-plan.json -u me@my.org"
+  ],
+  "importFailure": "Data plan file %s did not validate against the schema.",
+  "importFailureActions": "Did you run the force:data:tree:export command with the --plan flag?\nMake sure you are importing a plan file.\nYou can get help with the import plan schema by running $ sfdx force:data:tree:import --confighelp"
+}

--- a/packages/plugin-data/package.json
+++ b/packages/plugin-data/package.json
@@ -28,15 +28,7 @@
                 "description": "fetch records using SOQL"
               },
               "tree": {
-                "description": "import/export records using the tree API",
-                "subtopics": {
-                  "import": {
-                    "description": "import records using the tree API"
-                  },
-                  "export": {
-                    "description": "export records using the tree API"
-                  }
-                }
+                "description": "import/export records using the tree API"
               }
             }
           }

--- a/packages/plugin-data/package.json
+++ b/packages/plugin-data/package.json
@@ -28,7 +28,15 @@
                 "description": "fetch records using SOQL"
               },
               "tree": {
-                "description": "manipulate records using the tree API"
+                "description": "import/export records using the tree API",
+                "subtopics": {
+                  "import": {
+                    "description": "import records using the tree API"
+                  },
+                  "export": {
+                    "description": "export records using the tree API"
+                  }
+                }
               }
             }
           }

--- a/packages/plugin-data/schema/dataImportPlanSchema.json
+++ b/packages/plugin-data/schema/dataImportPlanSchema.json
@@ -1,0 +1,80 @@
+{
+    "_comment": "Copyright (c) 2016, salesforce.com, inc. All rights reserved. Licensed under the BSD 3-Clause license. For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "array",
+    "title": "Data Import Plan",
+    "description": "Schema for SFDX Toolbelt's data import plan JSON.",
+    "items": {
+        "type": "object",
+        "title": "SObject Type",
+        "description": "Definition of records to be insert per SObject Type",
+        "properties": {
+            "sobject": {
+                "type": "string",
+                "title": "Name of SObject",
+                "description": "Child file references must have SObject roots of this type"
+            },
+            "saveRefs": {
+                "type": "boolean",
+                "title": "Save References",
+                "description": "Post-save, save references (Name/ID) to be used for reference replacement in subsequent saves.  Applies to all data files for this SObject type.",
+                "default": false
+            },
+            "resolveRefs": {
+                "type": "boolean",
+                "title": "Resolve References",
+                "description": "Pre-save, replace @<reference> with ID from previous save.  Applies to all data files for this SObject type.",
+                "default": false
+            },
+            "files": {
+                "type": "array",
+                "title": "Files",
+                "description": "An array of files paths to load",
+                "items": {
+                    "title": "Filepath.",
+                    "description": "Filepath string or object to point to a JSON or XML file having data defined in SObject Tree format.",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "file": {
+                                    "type": "string",
+                                    "title": "Filepath schema",
+                                    "description": "Filepath to JSON or XML file having data defined in SObject Tree format"
+                                },
+                                "contentType": {
+                                    "title": "Filepath schema.",
+                                    "description": "If data file extension is not .json or .xml, provide content type.",
+                                    "enum": [
+                                        "application/json",
+                                        "application/xml"
+                                    ]
+                                },
+                                "saveRefs": {
+                                    "type": "boolean",
+                                    "title": "Save References",
+                                    "description": "Post-save, save references (Name/ID) to be used for reference replacement in subsequent saves.  Overrides SObject-level 'saveRefs' setting."
+                                },
+                                "resolveRefs": {
+                                    "type": "boolean",
+                                    "title": "Resolve References",
+                                    "description": "Pre-save, replace @<reference> with ID from previous save.  Overrides SObject-level 'replaceRefs' setting."
+                                }
+                            },
+                            "required": [
+                                "file"
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "required": [
+            "sobject",
+            "files"
+        ]
+    }
+}

--- a/packages/plugin-data/src/api/data/tree/executors.ts
+++ b/packages/plugin-data/src/api/data/tree/executors.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+
+export async function sequentialExecute(funcs: any[]): Promise<any> {
+  let result = Promise.resolve();
+  funcs.forEach((promiseFactory) => {
+    result = result.then(promiseFactory);
+  });
+  return result;
+}

--- a/packages/plugin-data/src/api/data/tree/exportApi.ts
+++ b/packages/plugin-data/src/api/data/tree/exportApi.ts
@@ -368,8 +368,7 @@ export class ExportApi {
     });
 
     if (!result) {
-      const metadataName: string = metadata.name;
-      throw new SfdxError(`Unable to find relationship field name for ${metadataName}`);
+      throw new SfdxError(`Unable to find relationship field name for ${metadata.name as string}`);
     }
 
     return result;
@@ -411,8 +410,7 @@ export class ExportApi {
     });
 
     if (!result) {
-      const metadataName: string = metadata.name;
-      throw new SfdxError(`Unable to find relation for ${metadataName}`);
+      throw new SfdxError(`Unable to find relation for ${metadata.name as string}`);
     }
 
     return result;

--- a/packages/plugin-data/src/api/data/tree/exportApi.ts
+++ b/packages/plugin-data/src/api/data/tree/exportApi.ts
@@ -1,0 +1,607 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+
+import * as path from 'path';
+import { fs, Logger, Messages, Org, SfdxError } from '@salesforce/core';
+import { AnyArray, AnyJson, get, getNumber, getString, has, isArray } from '@salesforce/ts-types';
+import { UX } from '@salesforce/command';
+import { sequentialExecute } from './executors';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-data', 'exportApi');
+
+const DATA_PLAN_FILENAME_PART = '-plan.json';
+
+const describe: any = {}; // holds metadata result for object type describe calls
+
+interface DataPlanPart {
+  sobject: string;
+  saveRefs: boolean;
+  resolveRefs: boolean;
+  files: string[];
+}
+
+export interface ExportConfig {
+  query: string;
+  outputDir?: string;
+  plan?: boolean;
+  prefix?: string;
+}
+
+/**
+ * Exports data from an org into sObject tree format.
+ */
+export class ExportApi {
+  private logger: Logger;
+
+  private objectTypeRegistry: any = {}; // registry for object type data plan descriptor
+  private referenceRegistry: any = {}; // registry of object type-specific id-to-ref mappings
+  private typeRefIndexes: any = {}; // registry for object type-specific ref counters
+
+  private config!: ExportConfig;
+
+  public constructor(private readonly org: Org, private readonly ux: UX) {
+    this.logger = Logger.childFromRoot(this.constructor.name);
+  }
+
+  /**
+   * Invokes the provided SOQL query against a target Org.  Results
+   * are converted into SObject Tree format.
+   *
+   * @param config
+   */
+  public async export(config: ExportConfig): Promise<AnyJson> {
+    this.config = this.validate(config);
+
+    const { outputDir, plan, query } = this.config;
+
+    if (outputDir) {
+      this.setupOutputDirectory(outputDir);
+    }
+
+    let queryResults: any;
+    try {
+      queryResults = await this.org.getConnection().query(query);
+    } catch (err) {
+      if (err.name === 'MALFORMED_QUERY') {
+        const errMsg = messages.getMessage('soqlMalformed');
+        const errMsgAction = messages.getMessage('soqlMalformedAction');
+        throw new SfdxError(errMsg, 'MalformedQuery', [errMsgAction]);
+      } else {
+        throw err;
+      }
+    }
+
+    const sobjectTree = await this.processQueryResults(queryResults);
+
+    if (!sobjectTree.records?.length) {
+      return sobjectTree;
+    }
+    if (plan) {
+      return this.generateDataPlan(sobjectTree);
+    } else {
+      const fileName = `${Object.keys(this.objectTypeRegistry).join('-')}.json`;
+      return this.writeDataFileSync(fileName, sobjectTree);
+    }
+  }
+
+  //   P R I V A T E   M E T H O D S
+
+  /**
+   * Ensures a valid query is defined in the export configuration,
+   * which can be either a soql query or a path to a file containing
+   * a soql query.
+   *
+   * @param config - The export configuration.
+   */
+  private validate(config: ExportConfig): ExportConfig {
+    if (!config.query) {
+      throw SfdxError.create('@salesforce/plugin-data', 'exportApi', 'queryNotProvided');
+    }
+
+    const filepath = path.resolve(process.cwd(), config.query);
+    if (fs.existsSync(filepath)) {
+      config.query = fs.readFileSync(filepath, 'utf8');
+
+      if (!config.query) {
+        throw SfdxError.create('@salesforce/plugin-data', 'exportApi', 'queryNotProvided');
+      }
+    }
+
+    config.query = config.query.toLowerCase().trim();
+    if (!config.query.startsWith('select')) {
+      throw SfdxError.create('@salesforce/plugin-data', 'exportApi', 'soqlInvalid', [config.query]);
+    }
+
+    return config;
+  }
+
+  private setupOutputDirectory(outputDir: string): void {
+    try {
+      fs.mkdirpSync(outputDir);
+    } catch (err) {
+      // It is ok if the directory already exist
+      if (err.name !== 'EEXIST') {
+        throw err;
+      }
+    }
+  }
+
+  // Process query results generating SObject Tree format
+  private async processQueryResults(recordList: any): Promise<any> {
+    await this.recordObjectTypes(recordList);
+
+    const { plan, query } = this.config;
+
+    const processedRecordList = await this.processRecordList(recordList);
+    // log record count; warn if > 200 and !options.plan
+    const recordCount = getNumber(processedRecordList, 'records.length', 0);
+    this.logger.debug(messages.getMessage('dataExportRecordCount', [recordCount, query]));
+    if (recordCount > 200 && !plan) {
+      this.ux.warn(messages.getMessage('dataExportRecordCountWarning', [recordCount, query]));
+    }
+    return this.finalApplyRefs(processedRecordList.records);
+  }
+
+  // Register object types and type hierarchy for plan generation
+  private async recordObjectTypes(recordList: any): Promise<any> {
+    const records = recordList.records;
+
+    if (!records.length) {
+      // TODO: should be on the command
+      this.ux.log('Query returned no results');
+      return recordList;
+    }
+
+    // top level object type
+    this.objectTypeRegistry[records[0].attributes.type as string] = {
+      order: 0,
+      type: records[0].attributes.type,
+      saveRefs: true, // post-save, record reference-to-id to be used for child reference resolution
+      resolveRefs: false, // pre-save, don't resolve relationship references to parent ids (from previous save)
+    };
+
+    records.forEach((record: any) => {
+      Object.keys(record).map((key) => {
+        const value = record[key];
+        if (value && getNumber(value, 'records.length')) {
+          const firstRec = value.records[0];
+          const type = getString(firstRec, 'attributes.type');
+          // found a related object, add to map
+          if (type && !this.objectTypeRegistry[type]) {
+            this.objectTypeRegistry[type] = {
+              order: 1,
+              type,
+              saveRefs: false, // assume child records will not be parents (may be changed later)
+              resolveRefs: true, // resolve relationship references to parent ids
+            };
+          }
+        }
+        return key;
+      });
+    });
+
+    // pre-load object metadata
+    const promises = Object.keys(this.objectTypeRegistry).map((key) => this.loadMetadata(key));
+    return Promise.all(promises).then(() => recordList);
+  }
+
+  private async processRecordList(recordList: any, parentRef?: any): Promise<any> {
+    // holds transformed sobject tree
+    const sobjectTree = { records: [] };
+
+    // visit each record in the list
+    const processRecordsFn = (record: any) => (): Promise<any> => this.processRecords(parentRef, record, sobjectTree);
+    const recordFns = recordList.records.map((record: any) => processRecordsFn(record));
+
+    // TODO: do we really need sequentialExecute?  Can't we just use Promise.all()?
+    await sequentialExecute(recordFns);
+    this.logger.debug(JSON.stringify(sobjectTree, null, 4));
+    return sobjectTree;
+  }
+
+  private async processRecords(parentRef: any, record: any, sobjectTree: any): Promise<any> {
+    // incremented every time we visit another record
+    const objRefId = this.incrementTypeRefIndex(record.attributes.type);
+
+    // add the attributes for this record, setting the type and reference
+    const treeRecord: any = {
+      attributes: {
+        type: record.attributes.type,
+        referenceId: objRefId,
+      },
+    };
+
+    // store the reference in a map with the record id
+    this.saveRecordRef(record, objRefId);
+
+    // handle each record attribute
+    await this.processRecordAttributes(record, treeRecord, objRefId);
+
+    if (parentRef && this.config.plan) {
+      const parentFieldName = getString(parentRef, 'fieldName', '');
+      if (!treeRecord[parentFieldName]) {
+        treeRecord[parentFieldName] = parentRef.id;
+      }
+    }
+    // add record to tree
+    sobjectTree.records.push(treeRecord);
+
+    return sobjectTree;
+  }
+
+  // Generate object type reference (<ObjectType>Ref<Counter>)
+  private incrementTypeRefIndex(type: string): string {
+    if (!this.typeRefIndexes[type]) {
+      this.typeRefIndexes[type] = 0;
+    }
+
+    return `${type}Ref${++this.typeRefIndexes[type]}`;
+  }
+
+  private async processRecordAttributes(record: any, treeRecord: any, objRefId: string): Promise<any> {
+    const promises = Object.keys(record).map((key) => this.processRecordAttribute(record, key, treeRecord, objRefId));
+
+    return Promise.all(promises).then(() => treeRecord);
+  }
+
+  private async processRecordAttribute(record: any, key: string, treeRecord: any, objRefId: string): Promise<any> {
+    return Promise.resolve().then(() => {
+      const field = record[key];
+
+      // skip attributes and id.  Data import does not accept records with IDs.
+      if (key === 'attributes' || key === 'Id') {
+        // If this is an attributes section then we need to add an object reference
+        this.saveRecordRef(record, objRefId);
+      } else {
+        return this.loadMetadata(record.attributes.type)
+          .then((metadata) => {
+            if (this.isQueryResult(metadata, key)) {
+              if (!field) {
+                // The parent has no child records, so return an empty records array
+                return { records: [] };
+              }
+              // handle child records
+              return this.loadMetadata(field.records[0].attributes.type).then((childMetadata) =>
+                this.processRecordList(field, {
+                  id: `@${objRefId}`,
+                  fieldName: this.getRelationshipFieldName(childMetadata, record.attributes.type),
+                })
+              );
+            } else {
+              // see if this is a relationship field
+              if (this.isRelationshipWithMetadata(metadata, key)) {
+                // related to which field?
+                const relTo = this.getRelatedToWithMetadata(metadata, key);
+                if (this.config.plan) {
+                  // find reference in record result
+                  if (this.objectTypeRegistry[relTo]) {
+                    // add ref to replace the value
+                    const id: string = record[key];
+                    const relatedObject = this.referenceRegistry[relTo];
+                    if (relatedObject) {
+                      const ref: string = relatedObject[id];
+                      // If ref is not found, then leave intact because we may not have processed
+                      // this parent fully. We'll go back through the sObject tree
+                      // later and replace the id with a reference.
+                      return ref ? `@${ref}` : id;
+                    } else {
+                      // again, this will just be the id for now and replaced with a ref later.
+                      return id;
+                    }
+                  } else {
+                    // TODO: what to do if ref not found?
+                    const recordId: string = record['Id'];
+                    this.logger.error(`Reference ${relTo} not found for ${key}.  Skipping record ${recordId}.`);
+                  }
+                }
+              } else {
+                // not a relationship field, simple key/value insertion
+                return record[key];
+              }
+            }
+
+            return null;
+          })
+          .then((processedAttribute) => {
+            if (processedAttribute !== null) {
+              treeRecord[key] = processedAttribute;
+            }
+
+            return Promise.resolve(null);
+          })
+          .catch((e) => {
+            throw e;
+          });
+      }
+
+      return Promise.resolve(null);
+    });
+  }
+
+  // Get sObject description and cache for given object type
+  private async loadMetadata(objectName: string): Promise<any> {
+    if (!describe[objectName]) {
+      const sObject = this.org.getConnection().sobject(objectName);
+      describe[objectName] = await sObject.describe();
+    }
+
+    return describe[objectName];
+  }
+
+  private isQueryResult(metadata: any, fieldName: string): any {
+    return metadata.childRelationships.some((cr: any) => cr.relationshipName === fieldName);
+  }
+
+  private isSpecificTypeWithMetadata(metadata: any, fieldName: string, fieldType: string): boolean {
+    for (let i = 0, fld; i < metadata.fields.length; i++) {
+      fld = metadata.fields[i];
+      if (fld.name.toLowerCase() === fieldName.toLowerCase()) {
+        if (fld.type.toLowerCase() === fieldType.toLowerCase()) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  private getRelationshipFieldName(metadata: any, parentName: string): string {
+    let result = '';
+    metadata.fields.some((field: any) => {
+      if (field.type === 'reference') {
+        for (const refTo of field.referenceTo) {
+          if (refTo === parentName) {
+            result = field.name;
+            return true;
+          }
+        }
+      }
+
+      return false;
+    });
+
+    if (!result) {
+      const metadataName: string = metadata.name;
+      throw new SfdxError(`Unable to find relationship field name for ${metadataName}`);
+    }
+
+    return result;
+  }
+
+  private isRelationship(objectName: string, fieldName: string): boolean {
+    const metadata = describe[objectName];
+    if (!metadata) {
+      throw new SfdxError(`Metadata not found for ${objectName}`);
+    }
+
+    return this.isRelationshipWithMetadata(metadata, fieldName);
+  }
+
+  private isRelationshipWithMetadata(metadata: any, fieldName: string): boolean {
+    return this.isSpecificTypeWithMetadata(metadata, fieldName, 'reference');
+  }
+
+  private getRelatedTo(objectName: string, fieldName: string): string {
+    const metadata = describe[objectName];
+    if (!metadata) {
+      throw new SfdxError(`Metadata not found for ${objectName}`);
+    }
+
+    return this.getRelatedToWithMetadata(metadata, fieldName);
+  }
+
+  private getRelatedToWithMetadata(metadata: any, fieldName: string): string {
+    let result = '';
+    metadata.fields.some((field: any) => {
+      if (field.name === fieldName) {
+        for (const refTo of field.referenceTo) {
+          result = refTo;
+          return true;
+        }
+      }
+
+      return false;
+    });
+
+    if (!result) {
+      const metadataName: string = metadata.name;
+      throw new SfdxError(`Unable to find relation for ${metadataName}`);
+    }
+
+    return result;
+  }
+
+  // Register object type's id to reference mapping
+  private saveRecordRef(obj: any, refId: string): void {
+    const id = path.basename(obj.attributes.url);
+    const ref = refId;
+
+    const type: string = obj.attributes.type;
+    if (typeof this.referenceRegistry[type] === 'undefined') {
+      this.referenceRegistry[type] = {};
+    }
+
+    // ensure no existing reference
+    const refEntry: string = this.referenceRegistry[type][id];
+    if (refEntry && refEntry !== ref) {
+      throw new SfdxError(`Overriding ${type} reference for ${id}: existing ${refEntry}, incoming ${ref}`);
+    }
+
+    this.referenceRegistry[type][id] = ref;
+  }
+
+  /**
+   * Walk the final data set and split out into files.  The main queried
+   * object is the parent, and has a different saveRefs and resolveRefs
+   * values.  All the references have been created at this point.
+   */
+  private generateDataPlan(sobjectTree: any): AnyJson {
+    const objects: any = {};
+    const dataPlan: DataPlanPart[] = [];
+    let topLevelObjectType: string;
+
+    // loop thru object tree extracting type-specific records into separate tree structure
+    sobjectTree.records.forEach((record: any) => {
+      topLevelObjectType = record.attributes.type;
+      if (!objects[topLevelObjectType]) {
+        objects[topLevelObjectType] = { records: [] };
+      }
+
+      Object.keys(record).map((key) => {
+        const childRecords: any = get(record, `${key}.records`);
+        if (childRecords) {
+          // found child records, add to type-specific registry
+          if (childRecords.length) {
+            const childObjectType: string = childRecords[0].attributes.type;
+            if (!objects[childObjectType]) {
+              objects[childObjectType] = { records: [] };
+            }
+
+            childRecords.forEach((child: any) => {
+              objects[childObjectType].records.push(child);
+            });
+          }
+
+          // remove child from top-level object structure
+          delete record[key];
+        }
+
+        return key;
+      });
+
+      objects[topLevelObjectType].records.push(record);
+    });
+
+    // sort object types based on insertion dependence
+    const objectsSorted = Object.keys(this.objectTypeRegistry).sort(
+      (a, b) => this.objectTypeRegistry[a].order - this.objectTypeRegistry[b].order
+    );
+
+    // write data files and update data plan
+    objectsSorted.forEach((key) => {
+      const dataPlanPart = this.writeObjectTypeDataFile(
+        key,
+        this.objectTypeRegistry[key].saveRefs,
+        this.objectTypeRegistry[key].resolveRefs,
+        `${key}s.json`,
+        objects[key]
+      );
+      dataPlan.push(dataPlanPart);
+    });
+
+    // write data plan file
+    const dataPlanFile = Object.keys(this.objectTypeRegistry).join('-') + DATA_PLAN_FILENAME_PART;
+
+    return this.writeDataFileSync(dataPlanFile, dataPlan as any);
+  }
+
+  // generate data plan stanza referencing written object type file
+  private writeObjectTypeDataFile(
+    type: string,
+    saveRefs: boolean,
+    resolveRefs: boolean,
+    fileName: string,
+    sObject: any
+  ): DataPlanPart {
+    let finalFilename = fileName;
+    if (this.config.prefix) {
+      finalFilename = `${this.config.prefix}-${fileName}`;
+    }
+    const dataPlanPart = {
+      sobject: type,
+      saveRefs,
+      resolveRefs,
+      files: [finalFilename],
+    };
+
+    this.writeDataFileSync(fileName, sObject);
+
+    return dataPlanPart;
+  }
+
+  /**
+   * This method is used as a second pass to establish references that couldn't be determined
+   * in the initial pass done by processRecordList. It looks for relationship fields that
+   * contain an id.
+   */
+  private finalApplyRefs(sobjectTree: any): { records: any } {
+    sobjectTree.forEach((record: any) => {
+      Object.keys(record).map((field) => {
+        if (record[field].records) {
+          // These are children
+          this.finalApplyRefs(record[field].records);
+        } else {
+          const objType: string = record.attributes.type;
+
+          if (this.isRelationship(objType, field)) {
+            const id: string = record[field].toString();
+            if (!id.startsWith('@')) {
+              const refTo = this.getRelatedTo(objType, field);
+              const ref: string = this.referenceRegistry[refTo][id];
+
+              if (!ref) {
+                throw new SfdxError(`${objType} reference to ${refTo} (${id}) not found in query results.`);
+              }
+
+              record[field] = `@${ref}`;
+
+              // Setup dependency ordering for later output
+              if (this.objectTypeRegistry[objType].order <= this.objectTypeRegistry[refTo].order) {
+                this.objectTypeRegistry[objType].order = this.objectTypeRegistry[refTo].order + 1;
+                this.objectTypeRegistry[refTo].saveRefs = true;
+                this.objectTypeRegistry[objType].resolveRefs = true;
+              }
+            }
+          }
+        }
+
+        return field;
+      });
+    });
+
+    return { records: sobjectTree };
+  }
+
+  private countRecords(records: AnyArray, count = 0): number {
+    count += records.length;
+    records.forEach((record: any) => {
+      Object.values(record).forEach((val: any) => {
+        if (val?.records) {
+          this.countRecords(val.records, count);
+        }
+      });
+    });
+    return count;
+  }
+
+  private writeDataFileSync(fileName: string, jsonObject: AnyJson): AnyJson {
+    let recordCount = 0;
+    const { outputDir, prefix } = this.config;
+
+    if (prefix) {
+      fileName = `${prefix}-${fileName}`;
+    }
+
+    if (outputDir) {
+      fileName = path.join(outputDir, fileName);
+    }
+
+    if (has(jsonObject, 'records') && isArray(jsonObject.records)) {
+      recordCount = this.countRecords(jsonObject.records);
+    }
+
+    fs.writeFileSync(fileName, JSON.stringify(jsonObject, null, 4));
+
+    // TODO: move this to the command
+    this.ux.log(`Wrote ${recordCount} records to ${fileName}`);
+
+    return jsonObject;
+  }
+}

--- a/packages/plugin-data/src/api/data/tree/exportApi.ts
+++ b/packages/plugin-data/src/api/data/tree/exportApi.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import { fs, Logger, Messages, Org, SfdxError } from '@salesforce/core';
 import { AnyArray, AnyJson, get, getNumber, getString, has, isArray } from '@salesforce/ts-types';
 import { UX } from '@salesforce/command';
+import { QueryResult } from 'jsforce';
 import { sequentialExecute } from './executors';
 
 Messages.importMessagesDirectory(__dirname);
@@ -65,7 +66,7 @@ export class ExportApi {
       this.setupOutputDirectory(outputDir);
     }
 
-    let queryResults: any;
+    let queryResults: QueryResult<unknown>;
     try {
       queryResults = await this.org.getConnection().query(query);
     } catch (err) {

--- a/packages/plugin-data/src/api/data/tree/importApi.ts
+++ b/packages/plugin-data/src/api/data/tree/importApi.ts
@@ -365,13 +365,9 @@ export class ImportApi {
     // replace with reference found in previously saved records
     if (resolveRefs && refMap) {
       // find and stash all '@' references
-
-      // Could optionally use String.match(regex) to avoid turning off the rule
-      /* eslint-disable no-cond-assign */
       while ((match = refRegex.exec(contentStr))) {
         foundRefs.add(match[1]);
       }
-      /* eslint-enable no-cond-assign */
 
       if (foundRefs.size > 0 && refMap.size === 0) {
         throw SfdxError.create('@salesforce/plugin-data', 'importApi', 'dataFileNoRefId', [filepath]);

--- a/packages/plugin-data/src/api/data/tree/importApi.ts
+++ b/packages/plugin-data/src/api/data/tree/importApi.ts
@@ -1,0 +1,496 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+
+import * as path from 'path';
+import * as util from 'util';
+
+import {
+  Dictionary,
+  isString,
+  isObject,
+  isArray,
+  getNumber,
+  getString,
+  AnyJson,
+  JsonMap,
+  JsonCollection,
+} from '@salesforce/ts-types';
+import { fs, Logger, Org, SfdxError, SchemaValidator } from '@salesforce/core';
+import { sequentialExecute } from './executors';
+
+const importPlanSchemaFile = path.join(__dirname, '..', '..', '..', '..', 'schema', 'dataImportPlanSchema.json');
+
+const sobjectTreeApiPartPattern = '%s/services/data/v%s/composite/tree/%s';
+const jsonContentType = 'application/json';
+const xmlContentType = 'application/xml';
+const jsonRefRegex = /[.]*["|'][A-Z0-9_]*["|'][ ]*:[ ]*["|']@([A-Z0-9_]*)["|'][.]*/gim;
+const xmlRefRegex = /[.]*<[A-Z0-9_]*>@([A-Z0-9_]*)<\/[A-Z0-9_]*[ID]>[.]*/gim;
+
+const INVALID_DATA_IMPORT_ERR_NAME = 'InvalidDataImport';
+
+interface DataImportComponents {
+  instanceUrl: string;
+  saveRefs?: boolean;
+  resolveRefs?: boolean;
+  refMap: Map<string, string>;
+  filepath: string;
+  contentType?: string;
+}
+
+export interface ImportConfig {
+  sobjectTreeFiles?: string[];
+  contentType?: string;
+  plan?: string;
+}
+
+interface ResponseRefs {
+  referenceId: string;
+  id: string;
+}
+
+export interface ImportResults {
+  responseRefs?: ResponseRefs[];
+  sobjectTypes?: AnyJson;
+  errors?: string[];
+}
+
+/**
+ * Imports data into an org that was exported to files using the export API.
+ */
+export class ImportApi {
+  private logger: Logger;
+  private responseRefs: ResponseRefs[] = [];
+  private sobjectUrlMap: Map<string, string>;
+  private schemaValidator: SchemaValidator;
+  private sobjectTypes: any = {}; // hash of sobject { referenceId: type }
+
+  private config!: ImportConfig;
+
+  // A JsonArray but we need to provide a better type to work with it properly.
+  private importPlanConfig: any;
+
+  public constructor(private readonly org: Org) {
+    this.logger = Logger.childFromRoot(this.constructor.name);
+
+    this.sobjectUrlMap = new Map<string, string>();
+    this.schemaValidator = new SchemaValidator(this.logger, importPlanSchemaFile);
+  }
+
+  /**
+   * Inserts given SObject Tree content into given target Org.
+   *
+   * Validation and options fix-up done in execute() instead
+   * of validate() to ensure that all execution paths are
+   * properly validated.
+   *
+   * @param config
+   */
+  public async import(config: ImportConfig): Promise<ImportResults> {
+    const importResults: ImportResults = {};
+
+    this.config = await this.validate(config);
+
+    const refMap = new Map();
+
+    const { contentType, plan, sobjectTreeFiles } = this.config;
+    const instanceUrl = this.org.getField(Org.Fields.INSTANCE_URL) as string;
+
+    const fileFns: any = [];
+    const planFns: any = [];
+    let importPlanRootPath: string;
+
+    if (sobjectTreeFiles?.length) {
+      sobjectTreeFiles.forEach((file) => {
+        const filepath = path.resolve(process.cwd(), file);
+        const importConfig: DataImportComponents = { instanceUrl, refMap, filepath, contentType };
+        fileFns.push(() => this.importSObjectTreeFile(importConfig));
+      });
+    }
+
+    if (plan && this.importPlanConfig) {
+      // REVIEWME: support both files and plan in same invocation?
+
+      importPlanRootPath = path.dirname(plan);
+
+      this.importPlanConfig.forEach((sobjectConfig: any) => {
+        const globalSaveRefs = sobjectConfig.saveRefs != null ? sobjectConfig.saveRefs : false;
+        const globalResolveRefs = sobjectConfig.resolveRefs != null ? sobjectConfig.resolveRefs : false;
+
+        sobjectConfig.files.forEach((fileDef: any) => {
+          let filepath;
+          let saveRefs = globalSaveRefs;
+          let resolveRefs = globalResolveRefs;
+
+          // file definition can be just a filepath or an object that
+          // has a filepath and overriding global config
+          if (isString(fileDef)) {
+            filepath = fileDef;
+          } else if (isObject(fileDef)) {
+            const def: any = fileDef;
+            filepath = def.file;
+
+            // override save references, if set
+            saveRefs = def.saveRefs == null ? globalSaveRefs : def.saveRefs;
+
+            // override resolve references, if set
+            resolveRefs = def.resolveRefs == null ? globalResolveRefs : def.resolveRefs;
+          } else {
+            throw new SfdxError('file definition format unknown.', 'InvalidDataImportPlan');
+          }
+
+          filepath = path.resolve(importPlanRootPath, filepath);
+          const importConfig: DataImportComponents = {
+            instanceUrl,
+            saveRefs,
+            resolveRefs,
+            refMap,
+            filepath,
+            contentType,
+          };
+          planFns.push(() => this.importSObjectTreeFile(importConfig));
+        });
+      });
+    }
+
+    try {
+      await sequentialExecute(fileFns);
+      await sequentialExecute(planFns);
+      importResults.responseRefs = this.responseRefs;
+      importResults.sobjectTypes = this.sobjectTypes;
+    } catch (err) {
+      if (err.errorCode === 'ERROR_HTTP_400' && err.message != null) {
+        let msg;
+        try {
+          msg = JSON.parse(err.message);
+          if (msg.hasErrors && msg.results && msg.results.length > 0) {
+            importResults.errors = msg.results;
+          }
+        } catch (e2) {
+          // throw original
+        }
+      }
+
+      throw err;
+    }
+
+    return importResults;
+  }
+
+  public getSchema(): JsonMap {
+    return this.schemaValidator.loadSync();
+  }
+
+  /**
+   * Validates the import configuration.  If a plan is passed, validates
+   * the plan per the schema.
+   *
+   * @param config - The data import configuration.
+   * @returns Promise.<ImportConfig>
+   */
+  private async validate(config: ImportConfig): Promise<ImportConfig> {
+    const { sobjectTreeFiles, plan } = config;
+
+    // --sobjecttreefiles option is required when --plan option is unset
+    if (!sobjectTreeFiles && !plan) {
+      const err = SfdxError.create('@salesforce/plugin-data', 'importApi', 'dataFileNotProvided');
+      err.name = INVALID_DATA_IMPORT_ERR_NAME;
+      throw err;
+    }
+
+    // Prevent both --sobjecttreefiles and --plan option from being set
+    if (sobjectTreeFiles && plan) {
+      const err = SfdxError.create('@salesforce/plugin-data', 'importApi', 'tooManyFiles');
+      err.name = INVALID_DATA_IMPORT_ERR_NAME;
+      throw err;
+    }
+
+    if (plan) {
+      const planPath = path.resolve(process.cwd(), plan);
+      try {
+        fs.statSync(planPath);
+      } catch (e) {
+        const err = SfdxError.create('@salesforce/plugin-data', 'importApi', 'dataFileNotFound', [planPath]);
+        err.name = INVALID_DATA_IMPORT_ERR_NAME;
+        throw err;
+      }
+
+      this.importPlanConfig = JSON.parse(fs.readFileSync(planPath, 'utf8'));
+      try {
+        await this.schemaValidator.validate(this.importPlanConfig);
+      } catch (err) {
+        if (err.name === 'ValidationSchemaFieldErrors') {
+          const e = SfdxError.create('@salesforce/plugin-data', 'importApi', 'dataPlanValidationError', [
+            planPath,
+            err.message,
+          ]);
+          e.name = INVALID_DATA_IMPORT_ERR_NAME;
+          throw e;
+        }
+        throw err;
+      }
+    }
+    return config;
+  }
+
+  /**
+   * Create a hash of sobject { ReferenceId: Type } assigned to this.sobjectTypes.
+   * Used to display the sobject type in the results.
+   *
+   * @param content  The content string defined by the file(s).
+   * @param isJson
+   */
+  private createSObjectTypeMap(content: string, isJson: boolean): void {
+    let contentJson;
+
+    const getTypes = (records = []): any => {
+      records.forEach((record) => {
+        Object.entries(record).forEach(([key, val]) => {
+          if (isObject(val)) {
+            const v: any = val;
+            if (key === 'attributes') {
+              const { referenceId, type } = v;
+              this.sobjectTypes[referenceId as string] = type;
+            } else {
+              if (isArray(v.records)) {
+                getTypes(v.records);
+              }
+            }
+          }
+        });
+      });
+    };
+
+    if (isJson) {
+      contentJson = JSON.parse(content);
+      if (isArray(contentJson.records)) {
+        getTypes(contentJson.records);
+      }
+    }
+  }
+
+  // Does some basic validation on the filepath and returns some file metadata such as
+  // isJson, refRegex, and headers.
+  private getSObjectTreeFileMeta(filepath: string, contentType?: string): Dictionary<any> {
+    const meta: Dictionary<any> = {
+      isJson: false,
+      headers: {},
+    };
+    let tmpContentType;
+
+    // explicitly validate filepath so, if not found, we can return friendly error message
+    try {
+      fs.statSync(filepath);
+    } catch (e) {
+      const err = SfdxError.create('@salesforce/plugin-data', 'importApi', 'dataFileNotFound', [filepath]);
+      err.name = INVALID_DATA_IMPORT_ERR_NAME;
+      throw err;
+    }
+
+    // determine content type
+    if (filepath.endsWith('.json')) {
+      tmpContentType = jsonContentType;
+      meta.isJson = true;
+      meta.refRegex = jsonRefRegex;
+    } else if (filepath.endsWith('.xml')) {
+      tmpContentType = xmlContentType;
+      meta.refRegex = xmlRefRegex;
+    }
+
+    // unable to determine content type from extension, was a global content type provided?
+    if (!tmpContentType) {
+      if (!contentType) {
+        const err = SfdxError.create('@salesforce/plugin-data', 'importApi', 'unknownContentType', [filepath]);
+        err.name = INVALID_DATA_IMPORT_ERR_NAME;
+        throw err;
+      } else if (contentType.toUpperCase() === 'JSON') {
+        tmpContentType = jsonContentType;
+        meta.isJson = true;
+        meta.refRegex = jsonRefRegex;
+      } else if (contentType.toUpperCase() === 'XML') {
+        tmpContentType = xmlContentType;
+        meta.refRegex = xmlRefRegex;
+      } else {
+        const err = SfdxError.create('@salesforce/plugin-data', 'importApi', 'dataFileUnsupported', [contentType]);
+        err.name = INVALID_DATA_IMPORT_ERR_NAME;
+        throw err;
+      }
+    }
+
+    meta.headers['content-type'] = tmpContentType;
+
+    return meta;
+  }
+
+  // Parse the SObject tree file, resolving any saved refs if specified.
+  // Return a promise with the contents of the SObject tree file and the type.
+  private async parseSObjectTreeFile(
+    filepath: string,
+    isJson: boolean,
+    refRegex: RegExp,
+    resolveRefs?: boolean,
+    refMap?: any
+  ): Promise<any> {
+    let contentStr: string;
+    let contentJson;
+    let match;
+    let sobject = '';
+    const foundRefs = new Set<string>();
+
+    // call identity() so the access token can be auto-updated
+    const content = await fs.readFile(filepath);
+    if (!content) {
+      throw SfdxError.create('@salesforce/plugin-data', 'importApi', 'dataFileEmpty', [filepath]);
+    }
+
+    contentStr = content.toString();
+
+    if (isJson) {
+      // is valid json?  (save round-trip to server)
+      try {
+        contentJson = JSON.parse(contentStr);
+
+        // All top level records should be of the same sObject type so just grab the first one
+        const type = getString(contentJson, 'records[0].attributes.type');
+        if (type) {
+          sobject = type.toLowerCase();
+        }
+      } catch (e) {
+        throw SfdxError.create('@salesforce/plugin-data', 'importApi', 'dataFileInvalidJson', [filepath]);
+      }
+    }
+
+    // if we're replacing references (@AcmeIncAccountId), find references in content and
+    // replace with reference found in previously saved records
+    if (resolveRefs && refMap) {
+      // find and stash all '@' references
+
+      // Could optionally use String.match(regex) to avoid turning off the rule
+      /* eslint-disable no-cond-assign */
+      while ((match = refRegex.exec(contentStr))) {
+        foundRefs.add(match[1]);
+      }
+      /* eslint-enable no-cond-assign */
+
+      if (foundRefs.size > 0 && refMap.size === 0) {
+        throw SfdxError.create('@salesforce/plugin-data', 'importApi', 'dataFileNoRefId', [filepath]);
+      }
+
+      this.logger.debug(`Found references: ${Array.from(foundRefs).toString()}`);
+
+      // loop thru found references and replace with id value
+      foundRefs.forEach((ref) => {
+        const value: string = refMap.get(ref.toLowerCase());
+        if (value == null) {
+          // REVIEWME: fail?
+          this.logger.warn(`Reference '${ref}' not found in saved record references (${filepath})`);
+        } else {
+          contentStr = contentStr.replace(new RegExp(`(["'>])@${ref}(["'<])`, 'igm'), `$1${value}$2`);
+        }
+      });
+    }
+
+    // Create map of SObject { referenceId: type } to display the type in output
+    this.createSObjectTypeMap(contentStr, isJson);
+
+    return { contentStr, sobject };
+  }
+
+  // generate REST API url: http://<sfdc-instance>/v<version>/composite/tree/<sobject>
+  // and send the request.
+  private async sendSObjectTreeRequest(
+    contentStr: string,
+    sobject: string,
+    instanceUrl: string,
+    headers: any
+  ): Promise<JsonCollection> {
+    const apiVersion = this.org.getConnection().getApiVersion();
+    let sobjectTreeApiUrl = this.sobjectUrlMap.get(sobject);
+
+    if (!sobjectTreeApiUrl) {
+      sobjectTreeApiUrl = util.format(sobjectTreeApiPartPattern, instanceUrl, apiVersion, sobject);
+      this.sobjectUrlMap.set(sobject, sobjectTreeApiUrl);
+    }
+
+    this.logger.debug(`SObject Tree API URL: ${sobjectTreeApiUrl}`);
+
+    // post request with to-be-insert sobject tree content
+    return this.org.getConnection().request({
+      method: 'POST',
+      url: sobjectTreeApiUrl,
+      body: contentStr,
+      headers,
+    });
+  }
+
+  // Parse the response from the SObjectTree request and save refs if specified.
+  private parseSObjectTreeResponse(
+    response: any,
+    filepath: string,
+    isJson: boolean,
+    saveRefs?: boolean,
+    refMap?: Map<string, string>
+  ): any {
+    if (isJson) {
+      this.logger.debug(`SObject Tree API results:  ${JSON.stringify(response, null, 4)}`);
+
+      if (response.hasErrors) {
+        throw SfdxError.create('@salesforce/plugin-data', 'importApi', 'dataImportFailed', [
+          filepath,
+          JSON.stringify(response.results, null, 4),
+        ]);
+      }
+
+      if (getNumber(response, 'results.length')) {
+        // REVIEWME: include filepath from which record was define?
+        // store results to be output to stdout in aggregated tabular format
+        this.responseRefs = this.responseRefs.concat(response.results);
+
+        // if enabled, save references to map to be used to replace references
+        // prior to subsequent saves
+        if (saveRefs) {
+          for (let i = 0, len = response.results.length, ref; i < len; i++) {
+            ref = response.results[i];
+            if (refMap) {
+              refMap.set(ref.referenceId.toLowerCase(), ref.id);
+            }
+          }
+        }
+      }
+    } else {
+      throw new SfdxError('SObject Tree API XML response parsing not implemented', 'FailedDataImport');
+    }
+
+    return response;
+  }
+
+  // Imports the SObjectTree from the provided files/plan by making a POST request to the server.
+  private async importSObjectTreeFile(components: DataImportComponents): Promise<any> {
+    // Get some file metadata
+    const { isJson, refRegex, headers } = this.getSObjectTreeFileMeta(components.filepath, components.contentType);
+
+    this.logger.debug(`Importing SObject Tree data from file ${components.filepath}`);
+
+    return this.parseSObjectTreeFile(components.filepath, isJson, refRegex, components.resolveRefs, components.refMap)
+      .then(({ contentStr, sobject }) =>
+        this.sendSObjectTreeRequest(contentStr, sobject, components.instanceUrl, headers)
+      )
+      .then((response) =>
+        this.parseSObjectTreeResponse(response, components.filepath, isJson, components.saveRefs, components.refMap)
+      )
+      .catch((error) => {
+        // break the error message string into the variables we want
+        if (error.errorCode === 'INVALID_FIELD') {
+          const field = error.message.split("'")[1];
+          const object = error.message.substr(error.message.lastIndexOf(' ') + 1, error.message.length);
+          throw SfdxError.create('@salesforce/plugin-data', 'importApi', 'FlsError', [field, object]);
+        }
+        throw SfdxError.wrap(error);
+      });
+  }
+}

--- a/packages/plugin-data/src/api/data/tree/importApi.ts
+++ b/packages/plugin-data/src/api/data/tree/importApi.ts
@@ -85,10 +85,6 @@ export class ImportApi {
   /**
    * Inserts given SObject Tree content into given target Org.
    *
-   * Validation and options fix-up done in execute() instead
-   * of validate() to ensure that all execution paths are
-   * properly validated.
-   *
    * @param config
    */
   public async import(config: ImportConfig): Promise<ImportResults> {
@@ -176,7 +172,7 @@ export class ImportApi {
         }
       }
 
-      throw err;
+      throw SfdxError.wrap(err);
     }
 
     return importResults;
@@ -232,7 +228,7 @@ export class ImportApi {
           e.name = INVALID_DATA_IMPORT_ERR_NAME;
           throw e;
         }
-        throw err;
+        throw SfdxError.wrap(err);
       }
     }
     return config;

--- a/packages/plugin-data/src/commands/force/data/tree/export.ts
+++ b/packages/plugin-data/src/commands/force/data/tree/export.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as os from 'os';
+
+import { SfdxCommand } from '@salesforce/command';
+import { flags, FlagsConfig } from '@salesforce/command';
+import { Messages, Org } from '@salesforce/core';
+import { ExportApi } from '../../../../lib/data/tree/exportApi';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-data', 'tree.export');
+
+export default class Export extends SfdxCommand {
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessage('examples').split(os.EOL);
+  public static readonly requiresProject = false;
+  public static readonly requiresUsername = true;
+  public static readonly flagsConfig: FlagsConfig = {
+    query: flags.string({
+      char: 'q',
+      description: messages.getMessage('query'),
+      required: true,
+    }),
+    plan: flags.boolean({
+      char: 'p',
+      description: messages.getMessage('plan'),
+    }),
+    prefix: flags.string({
+      char: 'x',
+      description: messages.getMessage('prefix'),
+    }),
+    outputdir: flags.directory({
+      char: 'd',
+      description: messages.getMessage('outputdir'),
+    }),
+  };
+
+  // Overrides SfdxCommand.  This is ensured since requiresUsername == true
+  protected org!: Org;
+
+  public async run(): Promise<unknown> {
+    const { query, plan, prefix, outputdir: outputDir } = this.flags;
+    const exportApi = new ExportApi(this.org, this.ux);
+    return exportApi.export({ query, plan, prefix, outputDir });
+  }
+}

--- a/packages/plugin-data/src/commands/force/data/tree/export.ts
+++ b/packages/plugin-data/src/commands/force/data/tree/export.ts
@@ -18,7 +18,6 @@ const messages = Messages.loadMessages('@salesforce/plugin-data', 'tree.export')
 export default class Export extends SfdxCommand {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
-  public static readonly requiresProject = false;
   public static readonly requiresUsername = true;
   public static readonly flagsConfig: FlagsConfig = {
     query: flags.string({

--- a/packages/plugin-data/src/commands/force/data/tree/export.ts
+++ b/packages/plugin-data/src/commands/force/data/tree/export.ts
@@ -10,7 +10,7 @@ import * as os from 'os';
 import { SfdxCommand } from '@salesforce/command';
 import { flags, FlagsConfig } from '@salesforce/command';
 import { Messages, Org } from '@salesforce/core';
-import { ExportApi } from '../../../../lib/data/tree/exportApi';
+import { ExportApi } from '../../../../api/data/tree/exportApi';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-data', 'tree.export');

--- a/packages/plugin-data/src/commands/force/data/tree/import.ts
+++ b/packages/plugin-data/src/commands/force/data/tree/import.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as os from 'os';
+
+import { flags, FlagsConfig, SfdxCommand, SfdxResult } from '@salesforce/command';
+import { Messages, Org, SchemaPrinter } from '@salesforce/core';
+import { getString, JsonMap } from '@salesforce/ts-types';
+import { ImportApi, ImportConfig } from '../../../../lib/data/tree/importApi';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-data', 'tree.import');
+
+interface ImportResult {
+  refId: string;
+  type: string;
+  id: string;
+}
+
+/**
+ * Command that provides data import capability via the SObject Tree Save API.
+ */
+export default class Import extends SfdxCommand {
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessage('examples').split(os.EOL);
+  public static readonly requiresProject = false;
+  public static readonly requiresUsername = true;
+  public static readonly flagsConfig: FlagsConfig = {
+    sobjecttreefiles: flags.array({
+      char: 'f',
+      description: messages.getMessage('sobjecttreefiles'),
+      exclusive: ['plan'],
+    }),
+    plan: flags.filepath({
+      char: 'p',
+      description: messages.getMessage('plan'),
+    }),
+    contenttype: flags.string({
+      char: 'c',
+      description: messages.getMessage('contenttype'),
+      hidden: true,
+    }),
+    // displays the schema for a data import plan
+    confighelp: flags.boolean({
+      description: messages.getMessage('confighelp'),
+    }),
+  };
+
+  public static result: SfdxResult = {
+    tableColumnData: {
+      columns: [
+        { key: 'refId', label: 'Reference ID' },
+        { key: 'type', label: 'Type' },
+        { key: 'id', label: 'ID' },
+      ],
+    },
+  };
+
+  // Overrides SfdxCommand.  This is ensured since requiresUsername == true
+  protected org!: Org;
+
+  public async run(): Promise<ImportResult[] | JsonMap> {
+    const importApi = new ImportApi(this.org);
+
+    if (this.flags.confighelp) {
+      // Display config help and return
+      const schema = importApi.getSchema();
+      if (!this.flags.json) {
+        const schemaLines = new SchemaPrinter(this.logger, schema).getLines();
+        schemaLines.forEach((line) => this.ux.log(line));
+        // turn off table output
+        this.result.tableColumnData = undefined;
+      }
+
+      return schema;
+    }
+
+    const importConfig: ImportConfig = {
+      sobjectTreeFiles: this.flags.sobjecttreefiles,
+      contentType: this.flags.contenttype,
+      plan: this.flags.plan,
+    };
+
+    const importResults = await importApi.import(importConfig);
+
+    let processedResult: ImportResult[] = [];
+    if (importResults.responseRefs?.length) {
+      processedResult = importResults.responseRefs.map((ref) => {
+        const type = getString(importResults.sobjectTypes, ref.referenceId, 'Unknown');
+        return { refId: ref.referenceId, type, id: ref.id } as ImportResult;
+      });
+    }
+    this.ux.styledHeader('Import Results');
+
+    return processedResult;
+  }
+}

--- a/packages/plugin-data/src/commands/force/data/tree/import.ts
+++ b/packages/plugin-data/src/commands/force/data/tree/import.ts
@@ -27,7 +27,6 @@ interface ImportResult {
 export default class Import extends SfdxCommand {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
-  public static readonly requiresProject = false;
   public static readonly requiresUsername = true;
   public static readonly flagsConfig: FlagsConfig = {
     sobjecttreefiles: flags.array({

--- a/packages/plugin-data/src/commands/force/data/tree/import.ts
+++ b/packages/plugin-data/src/commands/force/data/tree/import.ts
@@ -10,7 +10,7 @@ import * as os from 'os';
 import { flags, FlagsConfig, SfdxCommand, SfdxResult } from '@salesforce/command';
 import { Messages, Org, SchemaPrinter } from '@salesforce/core';
 import { getString, JsonMap } from '@salesforce/ts-types';
-import { ImportApi, ImportConfig } from '../../../../lib/data/tree/importApi';
+import { ImportApi, ImportConfig } from '../../../../api/data/tree/importApi';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-data', 'tree.import');

--- a/packages/plugin-data/test/api/data/tree/exportApi.test.ts
+++ b/packages/plugin-data/test/api/data/tree/exportApi.test.ts
@@ -1,0 +1,412 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+/* eslint-disable  @typescript-eslint/ban-ts-ignore */
+
+import * as sinon from 'sinon';
+
+import { fs as fsCore, Messages, Org, Connection } from '@salesforce/core';
+import { AnyJson } from '@salesforce/ts-types';
+import { UX } from '@salesforce/command';
+import { expect, assert } from 'chai';
+import { ExportApi } from '../../../../src/api/data/tree/exportApi';
+
+//
+//  TEST DATA
+//
+
+const status = 'New';
+const origin = 'Phone';
+const subject = 'Where are you from Hobbs?';
+const firstName = 'Roy';
+const lastName = 'Hobbs';
+const email = 'roy.hobbs@bigdogs.org';
+const phone = '512-757-6000';
+
+// Sample response from a query; used by the query stub
+const testRecordList = {
+  totalSize: 1,
+  done: true,
+  records: [
+    {
+      attributes: {
+        type: 'Account',
+        url: '/services/data/v39.0/sobjects/Account/001xx000003DHzvAAG',
+      },
+      Id: '001xx000003DHzvAAG',
+      Name: 'BigDogs',
+      Industry: 'Construction',
+      Cases: {
+        totalSize: 1,
+        done: true,
+        records: [
+          {
+            attributes: {
+              type: 'Case',
+              url: '/services/data/v39.0/sobjects/Case/500xx000000Yn2uAAC',
+            },
+            Status: status,
+            Origin: origin,
+            Subject: subject,
+            AccountId: '001xx000003DHzvAAG',
+          },
+        ],
+      },
+      Contacts: {
+        totalSize: 1,
+        done: true,
+        records: [
+          {
+            attributes: {
+              type: 'Contact',
+              url: '/services/data/v39.0/sobjects/Contact/003xx000004TpUeAAK',
+            },
+            FirstName: firstName,
+            LastName: lastName,
+            Email: email,
+            Phone: phone,
+          },
+        ],
+      },
+    },
+    {
+      attributes: {
+        type: 'Account',
+        url: '/services/data/v39.0/sobjects/Account/001xx000003DHzvBAG',
+      },
+      Id: '001xx000003DHzvBAG',
+      Name: 'HotDogs',
+      Industry: 'Fine Dining',
+      Cases: null,
+      Contacts: null,
+    },
+  ],
+};
+
+// Abbreviated response of Case SObject metadata used by the describe stub.
+const CASE_META = {
+  name: 'Case',
+  childRelationships: [],
+  fields: [
+    { name: 'AccountId', referenceTo: ['Account'], type: 'reference' },
+    { name: 'Status', referenceTo: [], type: 'picklist' },
+    { name: 'Origin', referenceTo: [], type: 'picklist' },
+    { name: 'Subject', referenceTo: [], type: 'string' },
+  ],
+};
+
+// Abbreviated response of Contact SObject metadata used by the describe stub.
+const CONTACT_META = {
+  name: 'Contact',
+  childRelationships: [],
+  fields: [
+    { name: 'AccountId', referenceTo: ['Account'], type: 'reference' },
+    { name: 'LastName', referenceTo: [], type: 'string' },
+    { name: 'FirstName', referenceTo: [], type: 'string' },
+    { name: 'Phone', referenceTo: [], type: 'phone' },
+    { name: 'Email', referenceTo: [], type: 'email' },
+  ],
+};
+
+// Abbreviated response of Account SObject metadata used by the describe stub.
+const ACCOUNT_META = {
+  name: 'Account',
+  childRelationships: [
+    { childSObject: 'Case', field: 'AccountId', relationshipName: 'Cases' },
+    {
+      childSObject: 'Contact',
+      field: 'AccountId',
+      relationshipName: 'Contacts',
+    },
+  ],
+  fields: [
+    { name: 'Name', referenceTo: [], type: 'string' },
+    { name: 'Type', referenceTo: [], type: 'picklist' },
+    { name: 'Industry', referenceTo: [], type: 'picklist' },
+  ],
+};
+
+// Expected file contents to be written by the export command based on the data returned by the stubs.
+const expectedFileContents = {
+  records: [
+    {
+      attributes: { type: 'Account', referenceId: 'AccountRef1' },
+      Name: testRecordList.records[0].Name,
+      Industry: testRecordList.records[0].Industry,
+      Cases: {
+        records: [
+          {
+            attributes: { type: 'Case', referenceId: 'CaseRef1' },
+            Status: status,
+            Origin: origin,
+            Subject: subject,
+          },
+        ],
+      },
+      Contacts: {
+        records: [
+          {
+            attributes: { type: 'Contact', referenceId: 'ContactRef1' },
+            FirstName: firstName,
+            LastName: lastName,
+            Email: email,
+            Phone: phone,
+          },
+        ],
+      },
+    },
+    {
+      attributes: { type: 'Account', referenceId: 'AccountRef2' },
+      Name: testRecordList.records[1].Name,
+      Industry: testRecordList.records[1].Industry,
+      Cases: { records: [] },
+      Contacts: { records: [] },
+    },
+  ],
+};
+
+// Expected plan file contents to be written by the export command based on the data returned by the stubs.
+const expectedPlanOutput = {
+  planFile: [
+    {
+      sobject: 'Account',
+      saveRefs: true,
+      resolveRefs: false,
+      files: ['Accounts.json'],
+    },
+    {
+      sobject: 'Case',
+      saveRefs: false,
+      resolveRefs: true,
+      files: ['Cases.json'],
+    },
+    {
+      sobject: 'Contact',
+      saveRefs: false,
+      resolveRefs: true,
+      files: ['Contacts.json'],
+    },
+  ],
+  Accounts: {
+    records: [
+      {
+        attributes: expectedFileContents.records[0].attributes,
+        Name: expectedFileContents.records[0].Name,
+        Industry: expectedFileContents.records[0].Industry,
+      },
+      {
+        attributes: expectedFileContents.records[1].attributes,
+        Name: expectedFileContents.records[1].Name,
+        Industry: expectedFileContents.records[1].Industry,
+      },
+    ],
+  },
+  Cases: expectedFileContents.records[0].Cases,
+  Contacts: expectedFileContents.records[0].Contacts,
+};
+
+function deepClone(obj: AnyJson) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+describe('Export API', () => {
+  const sandbox = sinon.createSandbox();
+  Messages.importMessagesDirectory(__dirname);
+  const messages = Messages.loadMessages('@salesforce/plugin-data', 'exportApi');
+  const testUsername = 'user@my.test';
+
+  let exportApi: ExportApi;
+  let writeStub: any;
+  let queryStub: any;
+  let sobjectStub: any;
+
+  beforeEach(async () => {
+    writeStub = sandbox.stub(fsCore, 'writeFileSync');
+    sandbox.stub(fsCore, 'existsSync').returns(false);
+
+    const testOrg = new Org({ aliasOrUsername: testUsername });
+    queryStub = sandbox.stub(Connection.prototype, 'query');
+    queryStub.resolves(deepClone(testRecordList));
+    sobjectStub = sandbox.stub(Connection.prototype, 'sobject');
+    sobjectStub.withArgs('Case').returns({
+      // @ts-ignore
+      describe: () => Promise.resolve(CASE_META),
+    });
+    sobjectStub.withArgs('Contact').returns({
+      // @ts-ignore
+      describe: () => Promise.resolve(CONTACT_META),
+    });
+    sobjectStub.withArgs('Account').returns({
+      // @ts-ignore
+      describe: () => Promise.resolve(ACCOUNT_META),
+    });
+    // @ts-ignore
+    sandbox.stub(Org.prototype, 'getConnection').returns({
+      query: queryStub,
+      // @ts-ignore
+      sobject: sobjectStub,
+    });
+    const ux = await UX.create();
+    sandbox.stub(ux, 'log');
+
+    exportApi = new ExportApi(testOrg, ux);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should throw an error when the soql param is unset', async () => {
+    try {
+      // @ts-ignore  This won't compile for TS but it's possible to use the ExportApi
+      //             from a JS plugin so ignoring the error.
+      await exportApi.export({ query: null });
+      assert.fail();
+    } catch (err) {
+      expect(writeStub.called).to.be.false;
+      expect(err.name).to.equal('queryNotProvided');
+      expect(err.message).to.equal(messages.getMessage('queryNotProvided'));
+    }
+  });
+
+  it('should throw an error when the soql query does not begin with "select"', async () => {
+    const query = 'update all the things!';
+
+    try {
+      await exportApi.export({ query });
+      assert.fail();
+    } catch (err) {
+      expect(writeStub.called).to.be.false;
+      expect(err.name).to.equal('soqlInvalid');
+      expect(err.message).to.equal(messages.getMessage('soqlInvalid', [query]));
+    }
+  });
+
+  it('should export query results to a file', async () => {
+    await exportApi.export({ query: 'select' });
+    const writeFileArgs = writeStub.args;
+    const filenameArg = writeFileArgs[0][0];
+    const fileContentsJsonArg = JSON.parse(writeFileArgs[0][1]);
+
+    expect(writeStub.callCount).to.equal(1);
+    expect(filenameArg).to.equal('Account-Case-Contact.json');
+    expect(fileContentsJsonArg).to.eql(expectedFileContents);
+  });
+
+  it('should export query results to a plan', async () => {
+    // clone the expected plan output so modifications don't affect other tests
+    const expectedPlan = deepClone(expectedPlanOutput);
+
+    // Add the refs to the expected output
+    expectedPlan.Cases.records[0].AccountId = '@AccountRef1';
+    expectedPlan.Contacts.records[0].AccountId = '@AccountRef1';
+
+    await exportApi.export({ query: 'select', plan: true });
+    expect(writeStub.callCount).to.equal(4);
+
+    const fsWriteCall1 = writeStub.args[0];
+    const fsWriteCall2 = writeStub.args[1];
+    const fsWriteCall3 = writeStub.args[2];
+    const fsWriteCall4 = writeStub.args[3];
+
+    // Verify files were written with expected filenames
+    expect(writeStub.calledWith('Accounts.json')).to.be.true;
+    expect(writeStub.calledWith('Cases.json')).to.be.true;
+    expect(writeStub.calledWith('Contacts.json')).to.be.true;
+    expect(writeStub.calledWith('Account-Case-Contact-plan.json')).to.be.true;
+
+    // Verify file contents
+    expect(JSON.parse(fsWriteCall1[1])).to.eql(expectedPlan.Accounts);
+    expect(JSON.parse(fsWriteCall2[1])).to.eql(expectedPlan.Cases);
+    expect(JSON.parse(fsWriteCall3[1])).to.eql(expectedPlan.Contacts);
+    expect(JSON.parse(fsWriteCall4[1])).to.eql(expectedPlan.planFile);
+  });
+
+  it('should export query results to a plan using a prefix', async () => {
+    const PREFIX = 'test';
+
+    // clone the expected plan output so modifications don't affect other tests
+    const expectedPlan = deepClone(expectedPlanOutput);
+
+    // Add the refs to the expected output
+    expectedPlan.Cases.records[0].AccountId = '@AccountRef1';
+    expectedPlan.Contacts.records[0].AccountId = '@AccountRef1';
+
+    // Modify plan file contents for the prefix
+    expectedPlan.planFile[0].files = [`${PREFIX}-Accounts.json`];
+    expectedPlan.planFile[1].files = [`${PREFIX}-Cases.json`];
+    expectedPlan.planFile[2].files = [`${PREFIX}-Contacts.json`];
+
+    await exportApi.export({
+      query: 'select',
+      plan: true,
+      prefix: PREFIX,
+    });
+    expect(writeStub.callCount).to.equal(4);
+
+    const fsWriteCall1 = writeStub.args[0];
+    const fsWriteCall2 = writeStub.args[1];
+    const fsWriteCall3 = writeStub.args[2];
+    const fsWriteCall4 = writeStub.args[3];
+
+    // Verify files were written with expected filenames
+    expect(writeStub.calledWith(`${PREFIX}-Accounts.json`)).to.be.true;
+    expect(writeStub.calledWith(`${PREFIX}-Cases.json`)).to.be.true;
+    expect(writeStub.calledWith(`${PREFIX}-Contacts.json`)).to.be.true;
+    expect(writeStub.calledWith(`${PREFIX}-Account-Case-Contact-plan.json`)).to.be.true;
+
+    // Verify file contents
+    expect(JSON.parse(fsWriteCall1[1])).to.eql(expectedPlan.Accounts);
+    expect(JSON.parse(fsWriteCall2[1])).to.eql(expectedPlan.Cases);
+    expect(JSON.parse(fsWriteCall3[1])).to.eql(expectedPlan.Contacts);
+    expect(JSON.parse(fsWriteCall4[1])).to.eql(expectedPlan.planFile);
+  });
+
+  it('should export query results to a file when query param is a file that contains a soql query', async () => {
+    sandbox.stub(fsCore, 'readFileSync').callsFake(() => 'select stuff');
+    // @ts-ignore
+    fsCore.existsSync['returns'](true);
+    await exportApi.export({ query: 'queryInaFile.txt' });
+    const writeFileArgs = writeStub.args;
+    const filenameArg = writeFileArgs[0][0];
+    const fileContentsJsonArg = JSON.parse(writeFileArgs[0][1]);
+
+    expect(writeStub.callCount).to.equal(1);
+    expect(filenameArg).to.equal('Account-Case-Contact.json');
+    expect(fileContentsJsonArg).to.eql(expectedFileContents);
+  });
+
+  it('should export invalid emails', async () => {
+    const expectedFile = deepClone(expectedFileContents);
+    expectedFile.records[0].Contacts.records[0].Email = '<invalid_email>';
+
+    queryStub.restore();
+    const testRecordList2 = deepClone(testRecordList);
+    testRecordList2.records[0].Contacts.records[0].Email = '<invalid_email>';
+    queryStub = sandbox.stub(Connection.prototype, 'query');
+    queryStub.resolves(testRecordList2);
+
+    // @ts-ignore
+    Org.prototype.getConnection.restore();
+    // @ts-ignore
+    sandbox.stub(Org.prototype, 'getConnection').returns({
+      query: queryStub,
+      // @ts-ignore
+      sobject: sobjectStub,
+    });
+
+    await exportApi.export({ query: 'select' });
+    const writeFileArgs = writeStub.args;
+    const filenameArg = writeFileArgs[0][0];
+    const fileContentsJsonArg = JSON.parse(writeFileArgs[0][1]);
+
+    expect(writeStub.callCount).to.equal(1);
+    expect(filenameArg).to.equal('Account-Case-Contact.json');
+    expect(fileContentsJsonArg).to.eql(expectedFile);
+  });
+});

--- a/packages/plugin-data/test/api/data/tree/importApi.test.ts
+++ b/packages/plugin-data/test/api/data/tree/importApi.test.ts
@@ -13,12 +13,11 @@ import * as path from 'path';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 
-import { fs as fsCore, Messages, SfdxError } from '@salesforce/core';
+import { fs as fsCore, Messages, Org, SfdxError } from '@salesforce/core';
 import { ImportApi, ImportConfig } from '../../../../src/api/data/tree/importApi';
 
 // Json files
-// const DataImportConfigHelpCommand = require('../../../lib/data/dataImportConfigHelpCommand');
-// const dataImportPlanSchema = require('../../../../schemas/dataImportPlanSchema.json');
+const dataImportPlanSchema = require('../../../../schema/dataImportPlanSchema.json');
 const accountsContactsTreeJSON = require('./test-files/accounts-contacts-tree.json');
 const accountsContactsPlanJSON = require('./test-files/accounts-contacts-plan.json');
 
@@ -616,6 +615,14 @@ describe('ImportApi', () => {
       expect(
         context.parseSObjectTreeResponse.calledWith(testResponse, filepath, testMeta.isJson, saveRefs, refMap)
       ).to.equal(true);
+    });
+  });
+
+  describe('getSchema', () => {
+    it('should return the schema', () => {
+      const org = new Org({ aliasOrUsername: 'import@test.org' });
+      const importApi = new ImportApi(org);
+      expect(importApi.getSchema()).to.deep.equal(dataImportPlanSchema);
     });
   });
 });

--- a/packages/plugin-data/test/api/data/tree/importApi.test.ts
+++ b/packages/plugin-data/test/api/data/tree/importApi.test.ts
@@ -1,0 +1,752 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+/* eslint-disable  @typescript-eslint/ban-ts-ignore */
+/* eslint-disable  @typescript-eslint/no-var-requires */
+
+import * as path from 'path';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import { fs as fsCore, Messages, SfdxError } from '@salesforce/core';
+import { ImportApi, ImportConfig } from '../../../../src/api/data/tree/importApi';
+
+// Json files
+// const DataImportConfigHelpCommand = require('../../../lib/data/dataImportConfigHelpCommand');
+// const dataImportPlanSchema = require('../../../../schemas/dataImportPlanSchema.json');
+const accountsContactsTreeJSON = require('./test-files/accounts-contacts-tree.json');
+const accountsContactsPlanJSON = require('./test-files/accounts-contacts-plan.json');
+
+// Sample response data
+// const sampleResponseData = [
+//   { referenceId: 'SampleAccountRef', id: '001xx000003DKpJAAW' },
+//   { referenceId: 'SampleAcct2Ref', id: '001xx000003DKpKAAW' },
+//   { referenceId: 'PresidentSmithRef', id: '003xx000004TtqCAAS' },
+//   { referenceId: 'VPEvansRef', id: '003xx000004TtqIAAS' }
+// ];
+
+const sampleSObjectTypes = {
+  SampleAccountRef: 'Account',
+  SampleAcct2Ref: 'Account',
+  PresidentSmithRef: 'Contact',
+  VPEvansRef: 'Contact',
+};
+
+// Sample command display data
+// const sampleDisplayData = [
+//   { refId: 'SampleAccountRef', type: 'Account', id: '001xx000003DKpJAAW' },
+//   { refId: 'SampleAcct2Ref', type: 'Account', id: '001xx000003DKpKAAW' },
+//   { refId: 'PresidentSmithRef', type: 'Contact', id: '003xx000004TtqCAAS' },
+//   { refId: 'VPEvansRef', type: 'Contact', id: '003xx000004TtqIAAS' }
+// ];
+
+const jsonRefRegex = /[.]*["|'][A-Z0-9_]*["|'][ ]*:[ ]*["|']@([A-Z0-9_]*)["|'][.]*/gim;
+
+describe('ImportApi', () => {
+  const sandbox = sinon.createSandbox();
+  Messages.importMessagesDirectory(__dirname);
+  const messages = Messages.loadMessages('@salesforce/plugin-data', 'importApi');
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('validate', () => {
+    let context: any;
+    let config: any;
+
+    beforeEach(() => {
+      context = {
+        schemaValidator: {
+          validate: sandbox.stub(),
+        },
+      };
+      config = {};
+    });
+
+    it('should throw an InvalidDataImport error when both --sobjecttreefiles and --plan ARE NOT set', async () => {
+      try {
+        // @ts-ignore
+        const rv = await ImportApi.prototype.validate.call(context, config);
+
+        // this should never execute but if it does it will cause the test to fail
+        expect(rv).to.throw('InvalidDataImport');
+      } catch (err) {
+        expect(err.name).to.equal('InvalidDataImport');
+        expect(err.message).to.equal(messages.getMessage('dataFileNotProvided'));
+      }
+    });
+
+    it('should throw an InvalidDataImport error when both --sobjecttreefiles and --plan ARE set', async () => {
+      config = {
+        sobjectTreeFiles: 'test_file.json',
+        plan: 'test_plan.json',
+      };
+      try {
+        // @ts-ignore
+        const rv = await ImportApi.prototype.validate.call(context, config);
+
+        // this should never execute but if it does it will cause the test to fail
+        expect(rv).to.throw('InvalidDataImport');
+      } catch (err) {
+        expect(err.name).to.equal('InvalidDataImport');
+        expect(err.message).to.equal(messages.getMessage('tooManyFiles'));
+      }
+    });
+
+    it('should validate a plan', async () => {
+      config = {
+        plan: path.join(__dirname, 'test-files', 'accounts-contacts-plan.json'),
+      };
+      context.schemaValidator.validate.returns(Promise.resolve());
+      // @ts-ignore
+      await ImportApi.prototype.validate.call(context, config);
+      expect(context.schemaValidator.validate.calledWith(accountsContactsPlanJSON)).to.equal(true);
+    });
+
+    it('should throw an InvalidDataImport error with invalid path to plan file', async () => {
+      config = {
+        plan: './test/unit/data/non-existant-plan.json',
+      };
+      const expectedFilePath = path.resolve(process.cwd(), config.plan);
+      try {
+        // @ts-ignore
+        const rv = await ImportApi.prototype.validate.call(context, config);
+
+        // this should never execute but if it does it will cause the test to fail
+        expect(rv).to.throw('InvalidDataImport');
+      } catch (err) {
+        expect(err.name).to.equal('InvalidDataImport');
+        expect(err.message).to.equal(messages.getMessage('dataFileNotFound', [expectedFilePath]));
+      }
+    });
+
+    it('should return a promise resolved with config with data file as input', async () => {
+      config = {
+        sobjectTreeFiles: path.join(__dirname, 'test-files', 'accounts-contacts-tree.json'),
+      };
+      // @ts-ignore
+      const opts = await ImportApi.prototype.validate.call(context, config);
+      expect(opts).to.eql(config);
+    });
+
+    it('should return a promise resolved with config with plan file as input', async () => {
+      config = {
+        plan: path.join(__dirname, 'test-files', 'accounts-contacts-plan.json'),
+      };
+      context.schemaValidator.validate.returns(Promise.resolve());
+      // @ts-ignore
+      const opts = await ImportApi.prototype.validate.call(context, config);
+      expect(opts).to.eql(config);
+    });
+  });
+
+  describe('import', () => {
+    let config: ImportConfig;
+    const refMap = new Map();
+    const instanceUrl = 'what is it';
+    const filepath = 'the_filepath';
+    const contentType = 'json';
+    const context: any = {
+      importSObjectTreeFile: () => {},
+      org: {
+        getField: () => instanceUrl,
+      },
+      validate: sandbox.stub(),
+    };
+
+    beforeEach(() => {
+      config = { contentType };
+      sandbox.stub(context, 'importSObjectTreeFile').resolves({});
+      sandbox.stub(path, 'resolve').callsFake(() => filepath);
+      sandbox.stub(path, 'dirname').callsFake(() => filepath);
+      context.validate.resolves(config);
+    });
+
+    it('should call importSObjectTreeFile once with correct args for single file import', async () => {
+      config.sobjectTreeFiles = ['data_file1.json'];
+      await ImportApi.prototype.import.call(context, config);
+      expect(context.importSObjectTreeFile.calledOnce).to.be.true;
+      const expectedArgs = { instanceUrl, refMap, filepath, contentType };
+      expect(context.importSObjectTreeFile.firstCall.args[0]).to.deep.equal(expectedArgs);
+    });
+
+    it('should call importSObjectTreeFile twice with correct args when importing 2 files, comma delimited', async () => {
+      config.sobjectTreeFiles = ['data_file1.json', 'data_file2.json'];
+      await ImportApi.prototype.import.call(context, config);
+      expect(context.importSObjectTreeFile.calledTwice).to.be.true;
+      const expectedArgs = { instanceUrl, refMap, filepath, contentType };
+      expect(context.importSObjectTreeFile.firstCall.args[0]).to.deep.equal(expectedArgs);
+    });
+
+    it('should call importSObjectTreeFile for plan import', async () => {
+      const saveRefs = true;
+      const resolveRefs = true;
+      config.plan = 'data_plan.json';
+      context.importPlanConfig = [
+        {
+          sobject: 'Broker__c',
+          saveRefs,
+          files: ['brokers-data.json'],
+        },
+        {
+          sobject: 'Property__c',
+          resolveRefs,
+          files: ['properties-data.json'],
+        },
+      ];
+      await ImportApi.prototype.import.call(context, config);
+
+      expect(context.importSObjectTreeFile.calledTwice).to.be.true;
+      const expectedArgs1 = {
+        instanceUrl,
+        saveRefs,
+        resolveRefs: false,
+        refMap,
+        filepath,
+        contentType,
+      };
+      const expectedArgs2 = {
+        instanceUrl,
+        saveRefs: false,
+        resolveRefs,
+        refMap,
+        filepath,
+        contentType,
+      };
+      expect(context.importSObjectTreeFile.firstCall.args[0]).to.deep.equal(expectedArgs1);
+      expect(context.importSObjectTreeFile.secondCall.args[0]).to.deep.equal(expectedArgs2);
+    });
+  });
+
+  describe('createSObjectTypeMap', () => {
+    const contentStr = JSON.stringify(accountsContactsTreeJSON);
+    let context: any;
+
+    beforeEach(() => {
+      context = {
+        sobjectTypes: {},
+      };
+    });
+
+    it('should set this.sobjectTypes using JSON data', () => {
+      // @ts-ignore
+      ImportApi.prototype.createSObjectTypeMap.call(context, contentStr, true);
+      expect(context.sobjectTypes).to.eql(sampleSObjectTypes);
+    });
+
+    // This will need to be updated when XML importing is supported
+    it('should NOT set this.sobjectTypes using non-JSON data', () => {
+      // @ts-ignore
+      ImportApi.prototype.createSObjectTypeMap.call(context, contentStr, false);
+      expect(context.sobjectTypes).to.eql({});
+    });
+  });
+
+  describe('getSObjectTreeFileMeta', () => {
+    it('should return expected import file metadata for json file without specifying content-type', () => {
+      const expectedMeta = {
+        isJson: true,
+        refRegex: jsonRefRegex,
+        headers: {
+          'content-type': 'application/json',
+        },
+      };
+      const filepath = path.join(__dirname, 'test-files', 'contacts-only-2.json');
+      // @ts-ignore
+      const rv = ImportApi.prototype.getSObjectTreeFileMeta(filepath);
+      expect(rv).to.eql(expectedMeta);
+    });
+
+    it('should return expected import file metadata for json file with specifying content-type', () => {
+      const expectedMeta = {
+        isJson: true,
+        refRegex: jsonRefRegex,
+        headers: {
+          'content-type': 'application/json',
+        },
+      };
+      const filepath = path.join(__dirname, 'test-files', 'contacts-only-2.sdx');
+      // @ts-ignore
+      const rv = ImportApi.prototype.getSObjectTreeFileMeta(filepath, 'json');
+      expect(rv).to.eql(expectedMeta);
+    });
+
+    it('should throw an InvalidDataImport error with invalid path to data file', () => {
+      const filepath = path.join(__dirname, 'test-files', 'invalid-data-file.json');
+      try {
+        // @ts-ignore
+        const rv = ImportApi.prototype.getSObjectTreeFileMeta(filepath);
+        // this should never execute but if it does it will cause the test to fail
+        expect(rv).to.throw('InvalidDataImport');
+      } catch (err) {
+        expect(err.name).to.equal('InvalidDataImport');
+        expect(err.message).to.equal(`Cannot find data file. Indicate a valid path: ${filepath}.`);
+      }
+    });
+
+    it('should throw an InvalidDataImport error with unknown data file extention and no content-type', () => {
+      const filepath = path.join(__dirname, 'test-files', 'contacts-only-2.sdx');
+      try {
+        // @ts-ignore
+        const rv = ImportApi.prototype.getSObjectTreeFileMeta(filepath);
+        // this should never execute but if it does it will cause the test to fail
+        expect(rv).to.throw('InvalidDataImport');
+      } catch (err) {
+        expect(err.name).to.equal('InvalidDataImport');
+        expect(err.message).to.equal(`Unable to determine content type for file: ${filepath}.`);
+      }
+    });
+
+    it('should throw an InvalidDataImport error with unknown data file extention and unsupported content-type', () => {
+      const filepath = path.join(__dirname, 'test-files', 'contacts-only-2.sdx');
+      try {
+        // @ts-ignore
+        const rv = ImportApi.prototype.getSObjectTreeFileMeta(filepath, 'txt');
+        // this should never execute but if it does it will cause the test to fail
+        expect(rv).to.throw('InvalidDataImport');
+      } catch (err) {
+        expect(err.name).to.equal('InvalidDataImport');
+        expect(err.message).to.equal('Content type: txt not supported.');
+      }
+    });
+  });
+
+  describe('parseSObjectTreeFile', () => {
+    const context: any = {
+      logger: {
+        warn: () => {},
+        debug: () => {},
+      },
+      createSObjectTypeMap: sinon.spy(),
+    };
+    let filepath: string;
+    let isJson: boolean;
+    let refRegex: RegExp;
+    let resolveRefs: boolean;
+    let refMap: any;
+
+    beforeEach(() => {
+      filepath = path.join(__dirname, 'test-files', 'accounts-contacts-tree.json');
+      isJson = true;
+      refRegex = jsonRefRegex;
+      resolveRefs = false;
+      refMap = new Map();
+    });
+
+    it('should call this.createSObjectTypeMap() with correct args', () =>
+      // @ts-ignore
+      ImportApi.prototype.parseSObjectTreeFile
+        .call(context, filepath, isJson, refRegex, resolveRefs, refMap)
+        .then(() => {
+          const actualArgs = context.createSObjectTypeMap.args[0];
+          expect(JSON.parse(actualArgs[0])).to.eql(accountsContactsTreeJSON);
+          expect(actualArgs[1]).to.eql(isJson);
+        }));
+
+    it('should return a Promise resolved with the contentStr and sobject', () =>
+      // @ts-ignore
+      ImportApi.prototype.parseSObjectTreeFile
+        .call(context, filepath, isJson, refRegex, resolveRefs, refMap)
+        .then((rv) => {
+          expect(JSON.parse(rv.contentStr)).to.eql(accountsContactsTreeJSON);
+          expect(rv.sobject).to.eql('account');
+        }));
+
+    it('should return an FlsError type error, or catch and wrap the error', () => {
+      const sfdxError = SfdxError.create('@salesforce/plugin-data', 'importApi', 'FlsError', ['field__c', 'object__c']);
+      // @ts-ignore
+      sandbox.stub(ImportApi.prototype, 'parseSObjectTreeFile').throws(sfdxError);
+
+      expect(() =>
+        // @ts-ignore
+        ImportApi.prototype.parseSObjectTreeFile.call(context, filepath, isJson, refRegex, resolveRefs, refMap)
+      ).to.throw(
+        "We couldn't process your request because you don't have access to field__c on object__c. To learn more about field-level security, visit Tips and Hints for Page Layouts and Field-Level Security in our Developer Documentation."
+      );
+    });
+
+    it('should resolve saved references', () => {
+      resolveRefs = true;
+      filepath = path.join(__dirname, 'test-files', 'contacts-only-1.json');
+      refMap.set('sampleaccountref', 'test_account_id1');
+      refMap.set('sampleacct2ref', 'test_account_id2');
+      // @ts-ignore
+      return ImportApi.prototype.parseSObjectTreeFile
+        .call(context, filepath, isJson, refRegex, resolveRefs, refMap)
+        .then((rv) => {
+          const contentJson = JSON.parse(rv.contentStr);
+          expect(contentJson.records[0].AccountId).to.equal(refMap.get('sampleaccountref'));
+          expect(contentJson.records[1].AccountId).to.equal(refMap.get('sampleacct2ref'));
+        });
+    });
+
+    it('should resolve saved references of custom objects', () => {
+      const fileContents = `{
+                "records": [{
+                    "attributes": {
+                        "type": "Property__c",
+                        "referenceId": "Property__cRef1"
+                    },
+                    "Name": "Seaport District Retreat",
+                    "Price__c": 450000,
+                    "Broker__c": "@CustomObj__cRef1"
+                },{
+                    "attributes": {
+                        "type": "Property__c",
+                        "referenceId": "Property__cRef2"
+                    },
+                    "Name": "Brendom Docks",
+                    "Price__c": 950000,
+                    "Broker__c": "@CustomObj__cRef2"
+                },{
+                    "attributes": {
+                        "type": "Property__c",
+                        "referenceId": "Property__cRef20"
+                    },
+                    "Name": "Brendom Docks",
+                    "Price__c": 950000,
+                    "Broker__c": "@CustomObj__cRef20"
+                }]
+            }`;
+      sandbox.stub(fsCore, 'readFile').resolves(fileContents);
+      resolveRefs = true;
+      filepath = '';
+      refMap.set('customobj__cref1', 'custom_id1');
+      refMap.set('customobj__cref2', 'custom_id2');
+      refMap.set('customobj__cref20', 'custom_id3');
+      // @ts-ignore
+      return ImportApi.prototype.parseSObjectTreeFile
+        .call(context, filepath, isJson, refRegex, resolveRefs, refMap)
+        .then((rv) => {
+          const contentJson = JSON.parse(rv.contentStr);
+          expect(contentJson.records[0].Broker__c).to.equal(refMap.get('customobj__cref1'));
+          expect(contentJson.records[1].Broker__c).to.equal(refMap.get('customobj__cref2'));
+          expect(contentJson.records[2].Broker__c).to.equal(refMap.get('customobj__cref20'));
+        });
+    });
+  });
+
+  describe('sendSObjectTreeRequest', () => {
+    const requestStub = sinon.stub().resolves();
+    const context = {
+      sobjectUrlMap: new Map(),
+      logger: {
+        debug: () => {},
+      },
+      org: {
+        getConnection: () => ({
+          getApiVersion: () => '50.0',
+          request: requestStub,
+        }),
+      },
+    };
+
+    const contentStr = 'test_content_str';
+    const sobject = 'test_sobject';
+    const headers = 'test_headers';
+
+    afterEach(() => {
+      requestStub.reset();
+    });
+
+    it('should call request() with correct args', () => {
+      const sobjectTreeApiUrl = 'test_instance_url/services/data/v50.0/composite/tree/test_sobject';
+      const expectedArgs = {
+        method: 'POST',
+        url: sobjectTreeApiUrl,
+        body: contentStr,
+        headers,
+      };
+      // @ts-ignore
+      ImportApi.prototype.sendSObjectTreeRequest.call(context, contentStr, sobject, 'test_instance_url', headers);
+      expect(requestStub.args[0][0]).to.eql(expectedArgs);
+    });
+
+    it('should call request() with correct args using sobjectUrlMap', () => {
+      const sobjectTreeApiUrl = 'test_sobject_tree_api_url';
+      context.sobjectUrlMap.get = () => sobjectTreeApiUrl;
+      const expectedArgs = {
+        method: 'POST',
+        url: sobjectTreeApiUrl,
+        body: contentStr,
+        headers,
+      };
+      // @ts-ignore
+      ImportApi.prototype.sendSObjectTreeRequest.call(context, contentStr, sobject, 'test_instance_url', headers);
+      expect(requestStub.args[0][0]).to.eql(expectedArgs);
+    });
+  });
+
+  describe('parseSObjectTreeResponse', () => {
+    let context: any;
+    let response: any;
+    let filepath: string;
+    let isJson: boolean;
+    let saveRefs: boolean;
+    let refMap: any;
+
+    beforeEach(() => {
+      context = {
+        logger: { debug: () => {} },
+        responseRefs: [],
+      };
+      response = { results: [] };
+      filepath = 'test_file_path';
+      isJson = true;
+      saveRefs = false;
+      refMap = new Map();
+    });
+
+    it('should return a Promise resolved with the response', () => {
+      // @ts-ignore
+      const rv: any = ImportApi.prototype.parseSObjectTreeResponse.call(
+        context,
+        response,
+        filepath,
+        isJson,
+        saveRefs,
+        refMap
+      );
+      expect(rv).to.eql(response);
+    });
+
+    it('should add the response results to the responseRefs array', () => {
+      response.results = [
+        { referenceId: '1000x', id: 1 },
+        { referenceId: '2000x', id: 2 },
+        { referenceId: '3000x', id: 3 },
+      ];
+      context.responseRefs.push({ referenceId: 9 });
+      // @ts-ignore
+      ImportApi.prototype.parseSObjectTreeResponse.call(context, response, filepath, isJson, saveRefs, refMap);
+      expect(context.responseRefs).to.eql([{ referenceId: 9 }, ...response.results]);
+    });
+
+    it('should save refs to the refMap if args.saveRefs is true', () => {
+      response.results = [
+        { referenceId: '1000x', id: 1 },
+        { referenceId: '2000x', id: 2 },
+        { referenceId: '3000x', id: 3 },
+      ];
+      saveRefs = true;
+      const expectedRefMap = new Map<string, number>();
+      response.results.reduce((map: Map<string, number>, res: any) => map.set(res.referenceId, res.id), expectedRefMap);
+      // @ts-ignore
+      ImportApi.prototype.parseSObjectTreeResponse.call(context, response, filepath, isJson, saveRefs, refMap);
+      expect(refMap).to.eql(expectedRefMap);
+    });
+  });
+
+  describe('importSObjectTreeFile', () => {
+    const testResponse = 'test_response';
+    const testMeta = {
+      isJson: true,
+      refRegex: 'test_ref_regex',
+      headers: 'test_headers',
+    };
+    const testParseResults = {
+      contentStr: 'test_content_str',
+      sobject: 'test_sobject',
+    };
+    const context: any = {
+      logger: { debug: () => {} },
+    };
+
+    const args = {
+      instanceUrl: 'test_instance_url',
+      saveRefs: 'test_save_refs',
+      resolveRefs: 'test_resolve_refs',
+      refMap: 'test_ref_map',
+      filepath: 'test_file_path',
+      contentType: 'test_content_type',
+    };
+
+    beforeEach(() => {
+      context.getSObjectTreeFileMeta = sinon.stub().returns(testMeta);
+      context.parseSObjectTreeFile = sinon.stub().resolves(testParseResults);
+      context.sendSObjectTreeRequest = sinon.stub().resolves(testResponse);
+      context.parseSObjectTreeResponse = sinon.stub();
+    });
+
+    it('should call getSObjectTreeFileMeta 1st with correct args', async () => {
+      // @ts-ignore
+      await ImportApi.prototype.importSObjectTreeFile.call(context, args);
+      expect(context.getSObjectTreeFileMeta.calledBefore(context.parseSObjectTreeFile)).to.equal(true);
+      expect(context.getSObjectTreeFileMeta.calledWith(args.filepath, args.contentType)).to.equal(true);
+    });
+
+    it('should call parseSObjectTreeFile 2nd with correct args', async () => {
+      // @ts-ignore
+      await ImportApi.prototype.importSObjectTreeFile.call(context, args);
+      expect(context.parseSObjectTreeFile.calledAfter(context.getSObjectTreeFileMeta)).to.equal(true);
+      expect(context.parseSObjectTreeFile.calledBefore(context.sendSObjectTreeRequest)).to.equal(true);
+      expect(
+        context.parseSObjectTreeFile.calledWith(
+          args.filepath,
+          testMeta.isJson,
+          testMeta.refRegex,
+          args.resolveRefs,
+          args.refMap
+        )
+      ).to.equal(true);
+    });
+
+    it('should call sendSObjectTreeRequest 3rd with correct args', async () => {
+      // @ts-ignore
+      await ImportApi.prototype.importSObjectTreeFile.call(context, args);
+      const { contentStr, sobject } = testParseResults;
+      expect(context.sendSObjectTreeRequest.calledAfter(context.parseSObjectTreeFile)).to.equal(true);
+      expect(context.sendSObjectTreeRequest.calledBefore(context.parseSObjectTreeResponse)).to.equal(true);
+      expect(
+        context.sendSObjectTreeRequest.calledWith(contentStr, sobject, args.instanceUrl, testMeta.headers)
+      ).to.equal(true);
+    });
+
+    it('should call parseSObjectTreeResponse 4th with correct args', async () => {
+      // @ts-ignore
+      await ImportApi.prototype.importSObjectTreeFile.call(context, args);
+      const { filepath, saveRefs, refMap } = args;
+      expect(context.parseSObjectTreeResponse.calledAfter(context.sendSObjectTreeRequest)).to.be.true;
+      expect(
+        context.parseSObjectTreeResponse.calledWith(testResponse, filepath, testMeta.isJson, saveRefs, refMap)
+      ).to.equal(true);
+    });
+  });
+});
+
+/**
+ * Use these as the basis for integration tests.
+ */
+// describe('data:import', () => {
+//   let force;
+//   let org;
+
+//   before(() => {
+//     workspace = new TestWorkspace();
+//     org = new Org();
+//     force = org.force;
+
+//     sandbox.stub(force, 'describeData').callsFake(() => Promise.resolve());
+
+//     // copy data files to workspace
+//     fse.copySync(path.join(dir, 'data'), path.join(workspace.getWorkspacePath(), 'data'));
+
+//     // Some test require a scratch org config in the workspace
+//     return workspace
+//       .configureHubOrg()
+//       .then(() => org.saveConfig(orgConfig))
+//       .then(() => workspace.configureWorkspaceScratchOrg());
+//   });
+
+//   after(() => {
+//     workspace.clean();
+//   });
+
+//   afterEach(() => {
+//     sandbox.restore();
+//   });
+
+//   describe('DataTreeImportCommand run()', () => {
+//     it('should output the plan schema when confighelp flag specified', async () => {
+//       const context = {
+//         flags: {
+//           confighelp: true,
+//           json: true
+//         },
+//         org: new Org()
+//       };
+//       const dataTreeImportCommand = new DataTreeImportCommand([], null);
+//       set(dataTreeImportCommand, 'ux', { log: sandbox.spy() });
+//       sandbox.stub(dataTreeImportCommand as any, 'resolveLegacyContext').callsFake(() => Promise.resolve(context));
+
+//       const outputJson = await dataTreeImportCommand.run();
+//       expect(outputJson).to.deep.equal(dataImportPlanSchema);
+//     });
+//   });
+
+//   // Test importing a single data file
+//   describe('#File', () => {
+//     beforeEach(() => {
+//       sandbox.stub(force, 'request').callsFake(() =>
+//         Promise.resolve({
+//           hasErrors: false,
+//           results: sampleResponseData
+//         })
+//       );
+//     });
+
+//     it('API: Should insert Accounts and child Contacts', () => {
+//       const dataImportCmd = new DataImportApi(org);
+//       const config = {
+//         json: true,
+//         username,
+//         sobjecttreefiles: './data/accounts-contacts-tree.json'
+//       };
+
+//       return dataImportCmd.execute(config).then(result => {
+//         expect(result).to.eql(sampleDisplayData);
+//       });
+//     });
+//   });
+
+//   // test importing via plan
+//   describe('#Plan', () => {
+//     const contactsOnly1 = [
+//       { referenceId: 'FrontDeskRef', id: '003xx000004TtqwAAC' },
+//       { referenceId: 'ManagerRef', id: '003xx000004TtqxAAC' }
+//     ];
+//     const contactsOnly2 = [
+//       { referenceId: 'JanitorRef', id: '003xx000004Ttr1AAC' },
+//       { referenceId: 'DeveloperRef', id: '003xx000004Ttr2AAC' }
+//     ];
+
+//     const sampleDisplayContacts1 = [
+//       { refId: 'FrontDeskRef', type: 'Contact', id: '003xx000004TtqwAAC' },
+//       { refId: 'ManagerRef', type: 'Contact', id: '003xx000004TtqxAAC' }
+//     ];
+
+//     const sampleDisplayContacts2 = [
+//       { refId: 'JanitorRef', type: 'Contact', id: '003xx000004Ttr1AAC' },
+//       { refId: 'DeveloperRef', type: 'Contact', id: '003xx000004Ttr2AAC' }
+//     ];
+
+//     let requestStub;
+
+//     beforeEach(() => {
+//       requestStub = sandbox.stub(force, 'request');
+//       requestStub.onCall(0).returns(Promise.resolve({ hasErrors: false, results: sampleResponseData }));
+//       requestStub.onCall(1).returns(Promise.resolve({ hasErrors: false, results: contactsOnly1 }));
+//       requestStub.onCall(2).returns(Promise.resolve({ hasErrors: false, results: contactsOnly2 }));
+//     });
+
+//     it('API: Should insert Accounts and child Contacts', () => {
+//       const dataImportCmd = new DataImportApi(org);
+//       const config = {
+//         json: true,
+//         username,
+//         plan: './data/accounts-contacts-plan.json',
+//         importPlanConfig: accountsContactsPlanJSON
+//       };
+//       const expected = [...sampleDisplayData, ...sampleDisplayContacts1, ...sampleDisplayContacts2];
+
+//       return dataImportCmd.execute(config).then(result => {
+//         expect(result).to.eql(expected);
+//       });
+//     });
+//   });
+
+//   describe('DataImportConfigHelpCommand', () => {
+//     it('should return the schema', () => {
+//       const dataImportConfigHelpCommand = new DataImportConfigHelpCommand();
+//       return dataImportConfigHelpCommand.execute({ org }).then(result => {
+//         expect(result).to.deep.equal(dataImportPlanSchema);
+//       });
+//     });
+//   });
+// });

--- a/packages/plugin-data/test/api/data/tree/test-files/accounts-contacts-plan.json
+++ b/packages/plugin-data/test/api/data/tree/test-files/accounts-contacts-plan.json
@@ -1,0 +1,23 @@
+[
+    {
+        "sobject": "Account",
+        "saveRefs": false,
+        "files": [
+            {
+                "file": "accounts-only.json",
+                "saveRefs": true
+            }
+        ]
+    },
+    {
+        "sobject": "Account",
+        "resolveRefs": false,
+        "files": [
+            {
+                "file": "contacts-only-1.json",
+                "resolveRefs": true
+            },
+            "contacts-only-2.json"
+        ]
+    }
+]

--- a/packages/plugin-data/test/api/data/tree/test-files/accounts-contacts-tree.json
+++ b/packages/plugin-data/test/api/data/tree/test-files/accounts-contacts-tree.json
@@ -1,0 +1,28 @@
+{
+"records" :[{
+    "attributes" : {"type" : "Account", "referenceId" : "SampleAccountRef"},
+    "name" : "SampleAccount",
+    "phone" : "1234567890",
+    "website" : "www.salesforce.com",
+    "numberOfEmployees" : "100",
+    "industry" : "Banking",
+    "Contacts" : {
+      "records" : [{
+         "attributes" : {"type" : "Contact", "referenceId" : "PresidentSmithRef"},
+         "lastname" : "Smith",
+         "title" : "President"
+         },{         
+         "attributes" : {"type" : "Contact", "referenceId" : "VPEvansRef"},
+         "lastname" : "Evans",
+         "title" : "Vice President"
+         }]
+      }
+    },{
+    "attributes" : {"type" : "Account", "referenceId" : "SampleAcct2Ref"},
+    "name" : "SampleAccount2",
+    "phone" : "1234567890",
+    "website" : "www.salesforce2.com",
+    "numberOfEmployees" : "100",
+    "industry" : "Banking"
+     }]
+}

--- a/packages/plugin-data/test/api/data/tree/test-files/accounts-only.json
+++ b/packages/plugin-data/test/api/data/tree/test-files/accounts-only.json
@@ -1,0 +1,28 @@
+{
+"records" :[{
+    "attributes" : {"type" : "Account", "referenceId" : "SampleAccountRef"},
+    "name" : "SampleAccount",
+    "phone" : "1234567890",
+    "website" : "www.salesforce.com",
+    "numberOfEmployees" : "100",
+    "industry" : "Banking",
+    "Contacts" : {
+      "records" : [{
+         "attributes" : {"type" : "Contact", "referenceId" : "PresidentSmithRef"},
+         "lastname" : "Smith",
+         "title" : "President"
+         },{         
+         "attributes" : {"type" : "Contact", "referenceId" : "VPEvansRef"},
+         "lastname" : "Evans",
+         "title" : "Vice President"
+         }]
+      }
+    },{
+    "attributes" : {"type" : "Account", "referenceId" : "SampleAcct2Ref"},
+    "name" : "SampleAccount2",
+    "phone" : "1234567890",
+    "website" : "www.salesforce2.com",
+    "numberOfEmployees" : "100",
+    "industry" : "Banking"
+     }]
+}

--- a/packages/plugin-data/test/api/data/tree/test-files/contacts-only-1.json
+++ b/packages/plugin-data/test/api/data/tree/test-files/contacts-only-1.json
@@ -1,0 +1,13 @@
+{
+  "records" : [{
+     "attributes" : {"type" : "Contact", "referenceId" : "FrontDeskRef"},
+     "lastname" : "Washington",
+     "title" : "President",
+     "AccountId" : "@SampleAccountRef"
+     },{         
+     "attributes" : {"type" : "Contact", "referenceId" : "ManagerRef"},
+     "lastname" : "Woods",
+     "title" : "Vice President",
+     "AccountId" : "@SampleAcct2Ref"
+     }]
+}

--- a/packages/plugin-data/test/api/data/tree/test-files/contacts-only-2.json
+++ b/packages/plugin-data/test/api/data/tree/test-files/contacts-only-2.json
@@ -1,0 +1,11 @@
+{
+  "records" : [{
+     "attributes" : {"type" : "Contact", "referenceId" : "JanitorRef"},
+     "lastname" : "Williams",
+     "title" : "President"
+     },{         
+     "attributes" : {"type" : "Contact", "referenceId" : "DeveloperRef"},
+     "lastname" : "Davenport",
+     "title" : "Vice President"
+     }]
+}

--- a/packages/plugin-data/test/api/data/tree/test-files/contacts-only-2.sdx
+++ b/packages/plugin-data/test/api/data/tree/test-files/contacts-only-2.sdx
@@ -1,0 +1,11 @@
+{
+  "records" : [{
+     "attributes" : {"type" : "Contact", "referenceId" : "JanitorRef"},
+     "lastname" : "Williams",
+     "title" : "President"
+     },{         
+     "attributes" : {"type" : "Contact", "referenceId" : "DeveloperRef"},
+     "lastname" : "Davenport",
+     "title" : "Vice President"
+     }]
+}

--- a/packages/plugin-data/test/commands/force/data/tree/export.test.ts
+++ b/packages/plugin-data/test/commands/force/data/tree/export.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect, test } from '@salesforce/command/lib/test';
+import { ensureJsonMap, ensureString, isString } from '@salesforce/ts-types';
+
+const query = 'SELECT Id, Name from Account';
+
+// Query response used by the connection stub.
+const queryResponse = {
+  totalSize: 1,
+  done: true,
+  records: [
+    {
+      attributes: {
+        type: 'Account',
+        url: '/services/data/v51.0/sobjects/Account/0019A00000GNvvAQAT',
+      },
+      Id: '0019A00000GNvvAQAT',
+      Name: 'Sample Account for Entitlements',
+    },
+  ],
+};
+
+// Abbreviated response of Account SObject metadata used by the connection stub.
+const ACCOUNT_META = {
+  name: 'Account',
+  childRelationships: [
+    { childSObject: 'Case', field: 'AccountId', relationshipName: 'Cases' },
+    {
+      childSObject: 'Contact',
+      field: 'AccountId',
+      relationshipName: 'Contacts',
+    },
+  ],
+  fields: [
+    { name: 'Name', referenceTo: [], type: 'string' },
+    { name: 'Type', referenceTo: [], type: 'picklist' },
+    { name: 'Industry', referenceTo: [], type: 'picklist' },
+  ],
+};
+
+describe('force:data:tree:export', () => {
+  test
+    .withOrg({ username: 'test@org.com' }, true)
+    .withConnectionRequest((request) => {
+      if (isString(request) && request.includes('sobjects/Account/describe')) {
+        return Promise.resolve(ACCOUNT_META);
+      } else {
+        const requestMap = ensureJsonMap(request);
+        if (ensureString(requestMap.url).includes('query?q=select')) {
+          return Promise.resolve(queryResponse);
+        }
+      }
+      return Promise.resolve({});
+    })
+    .stdout()
+    .command(['force:data:tree:export', '--targetusername', 'test@org.com', '--query', query, '--json'])
+    .it('returns Account record', (ctx) => {
+      const result = JSON.parse(ctx.stdout);
+      expect(result.status).to.equal(0);
+      expect(result.result).to.deep.equal({
+        records: [
+          {
+            attributes: {
+              type: 'Account',
+              referenceId: 'AccountRef1',
+            },
+            Name: 'Sample Account for Entitlements',
+          },
+        ],
+      });
+    });
+
+  test
+    .withOrg({ username: 'test@org.com' }, true)
+    .stdout()
+    .command(['force:data:tree:export', '--targetusername', 'test@org.com', '--json'])
+    .it('should throw an error if --query is not provided', (ctx) => {
+      const result = JSON.parse(ctx.stdout);
+      expect(result.status).to.equal(1);
+      expect(result.message).to.include('Missing required flag');
+    });
+});

--- a/packages/plugin-data/test/commands/force/data/tree/import.test.ts
+++ b/packages/plugin-data/test/commands/force/data/tree/import.test.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/* eslint-disable  @typescript-eslint/no-var-requires */
+
+import { join as pathJoin } from 'path';
+import { expect, test } from '@salesforce/command/lib/test';
+import { ensureJsonMap, ensureString } from '@salesforce/ts-types';
+
+const dataImportPlanSchema = require('../../../../../schema/dataImportPlanSchema.json');
+
+const expectedImportResult = [
+  {
+    refId: 'SampleAccountRef',
+    type: 'Account',
+    id: '0019A00000GkC21QAF',
+  },
+  {
+    refId: 'SampleAcct2Ref',
+    type: 'Account',
+    id: '0019A00000GkC22QAF',
+  },
+  {
+    refId: 'PresidentSmithRef',
+    type: 'Contact',
+    id: '0039A00000Bzy8kQAB',
+  },
+  {
+    refId: 'VPEvansRef',
+    type: 'Contact',
+    id: '0039A00000Bzy8lQAB',
+  },
+];
+
+describe('force:data:tree:import', () => {
+  test
+    .withOrg({ username: 'test@org.com' }, true)
+    .withConnectionRequest((request) => {
+      const requestMap = ensureJsonMap(request);
+      if (ensureString(requestMap.url).includes('composite/tree/account')) {
+        return Promise.resolve({
+          hasErrors: false,
+          results: [
+            { referenceId: 'SampleAccountRef', id: '0019A00000GkC21QAF' },
+            { referenceId: 'SampleAcct2Ref', id: '0019A00000GkC22QAF' },
+            { referenceId: 'PresidentSmithRef', id: '0039A00000Bzy8kQAB' },
+            { referenceId: 'VPEvansRef', id: '0039A00000Bzy8lQAB' },
+          ],
+        });
+      }
+      return Promise.resolve({});
+    })
+    .stdout()
+    .command([
+      'force:data:tree:import',
+      '--targetusername',
+      'test@org.com',
+      '--sobjecttreefiles',
+      pathJoin(__dirname, '..', '..', '..', '..', 'api', 'data', 'tree', 'test-files', 'accounts-contacts-tree.json'),
+      '--json',
+    ])
+    .it('returns 4 reference entries', (ctx) => {
+      const result = JSON.parse(ctx.stdout);
+      expect(result.status).to.equal(0);
+      expect(result.result).to.deep.equal(expectedImportResult);
+    });
+
+  test
+    .withOrg({ username: 'test@org.com' }, true)
+    .withConnectionRequest((request) => {
+      const requestMap = ensureJsonMap(request);
+      if (ensureString(requestMap.url).includes('composite/tree/account')) {
+        return Promise.resolve({
+          hasErrors: false,
+          results: [
+            { referenceId: 'SampleAccountRef', id: '0019A00000GkC21QAF' },
+            { referenceId: 'SampleAcct2Ref', id: '0019A00000GkC22QAF' },
+            { referenceId: 'PresidentSmithRef', id: '0039A00000Bzy8kQAB' },
+            { referenceId: 'VPEvansRef', id: '0039A00000Bzy8lQAB' },
+          ],
+        });
+      }
+      return Promise.resolve({});
+    })
+    .stdout()
+    .command([
+      'force:data:tree:import',
+      '--targetusername',
+      'test@org.com',
+      '--plan',
+      pathJoin(__dirname, '..', '..', '..', '..', 'api', 'data', 'tree', 'test-files', 'accounts-contacts-plan.json'),
+      '--json',
+    ])
+    .it('returns 4 reference entries', (ctx) => {
+      const result = JSON.parse(ctx.stdout);
+      expect(result.status).to.equal(0);
+      expect(result.result).to.deep.equal(expectedImportResult);
+    });
+
+  test
+    .withOrg({ username: 'test@org.com' }, true)
+    .stdout()
+    .command(['force:data:tree:import', '--targetusername', 'test@org.com', '--confighelp', '--json'])
+    .it('should return the schema with --confighelp param', (ctx) => {
+      const result = JSON.parse(ctx.stdout);
+      expect(result.status).to.equal(0);
+      expect(result.result).to.deep.equal(dataImportPlanSchema);
+    });
+
+  test
+    .withOrg({ username: 'test@org.com' }, true)
+    .stdout()
+    .command(['force:data:tree:import', '--targetusername', 'test@org.com', '--json'])
+    .it('should throw an error if --query is not provided', (ctx) => {
+      const result = JSON.parse(ctx.stdout);
+      expect(result.status).to.equal(1);
+      expect(result.message).to.include('Provide a data plan or file(s).');
+    });
+});


### PR DESCRIPTION
…ce-alm to @salesforce/plugin-data

### What does this PR do?
Adds `force:data:tree:export` and `force:data:tree:import` commands
Adds messages
Adds API classes that are not ready to be moved to `@salesforce/data`
Adds unit tests

### What issues does this PR fix or reference?
@W-8449687@