### PR TITLE
fix: parse csv as utf-8 and enable bom parsing

### DIFF
--- a/packages/plugin-data/src/batcher.ts
+++ b/packages/plugin-data/src/batcher.ts
@@ -303,6 +303,7 @@ export class Batcher {
         // library option is snakecase
         // eslint-disable-next-line @typescript-eslint/camelcase
         skip_empty_lines: true,
+        bom: true,
       });
 
       readStream.pipe(parser);

--- a/packages/plugin-data/src/commands/force/data/bulk/delete.ts
+++ b/packages/plugin-data/src/commands/force/data/bulk/delete.ts
@@ -46,7 +46,7 @@ export default class Delete extends DataCommand {
       const conn: Connection = this.org.getConnection();
       this.ux.startSpinner('Bulk Delete');
 
-      const csvRecords: ReadStream = fs.createReadStream(this.flags.csvfile);
+      const csvRecords: ReadStream = fs.createReadStream(this.flags.csvfile, { encoding: 'utf-8' });
       const job: Job = conn.bulk.createJob(this.flags.sobjecttype, 'delete');
 
       const batcher: Batcher = new Batcher(conn, this.ux);

--- a/packages/plugin-data/src/commands/force/data/bulk/upsert.ts
+++ b/packages/plugin-data/src/commands/force/data/bulk/upsert.ts
@@ -49,7 +49,7 @@ export default class Upsert extends DataCommand {
     await this.throwIfFileDoesntExist(this.flags.csvfile);
 
     const batcher: Batcher = new Batcher(conn, this.ux);
-    const csvStream: ReadStream = fs.createReadStream(this.flags.csvfile);
+    const csvStream: ReadStream = fs.createReadStream(this.flags.csvfile, { encoding: 'utf-8' });
 
     const job = conn.bulk.createJob(this.flags.sobjecttype, 'upsert', {
       extIdField: this.flags.externalid,


### PR DESCRIPTION
### What does this PR do?
passes csv to utf-8 encoding, and then adds the bom parsing option to the parser, which is now safe because the files are utf-8 encoded.

### What issues does this PR fix or reference?
@W-8836961@
https://github.com/forcedotcom/cli/issues/720 