### PR TITLE
fix: commands ignore --usetoolingapi

### DIFF
--- a/packages/plugin-data/src/dataCommand.ts
+++ b/packages/plugin-data/src/dataCommand.ts
@@ -94,7 +94,7 @@ export abstract class DataCommand extends SfdxCommand {
   }
 
   public getConnection(): BaseConnection {
-    const connection: BaseConnection & ConnectionInternals = this.flags.useToolingApi
+    const connection: BaseConnection & ConnectionInternals = this.flags.usetoolingapi
       ? this.org.getConnection().tooling
       : this.org.getConnection();
 


### PR DESCRIPTION
### What does this PR do?
fix casing to honor the flag `usetoolingapi`

### What issues does this PR fix or reference?
@W-8879900@