### PR TITLE
chore: remove codecov command

### DIFF
--- a/.github/autointegrator.yml
+++ b/.github/autointegrator.yml
@@ -1,2 +1,0 @@
-triggers:
-  master: [develop]

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "postinstall": "yarn bootstrap",
     "prepack": "lerna run prepack",
     "test": "lerna run test",
-    "test:nuts": "lerna run test:nuts",
-    "codecov": "codecov --disable=gcov"
+    "test:nuts": "lerna run test:nuts"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1",


### PR DESCRIPTION
### What does this PR do?
Removes `codecov` command from `package.json`
It also remove `autointegrator.yml` from `.github` directory

### What issues does this PR fix or reference?
@W-9228425@
