### PR TITLE
Sm/signing fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ workflows:
           requires:
             - release-management/test-package
       - release-management/release-lerna-packages:
-          sign: packages/plugin-data
+          sign: '@salesforces/plugin-data'
           requires:
             - release-management/test-package
           filters:

--- a/packages/plugin-data/package.json
+++ b/packages/plugin-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/plugin-data",
-  "version": "0.4.12",
+  "version": "0.5.0",
   "description": "Plugin for salesforce data commands",
   "author": "Salesforce",
   "homepage": "https://github.com/salesforcecli/data/tree/main/packages/plugin-data#readme",


### PR DESCRIPTION
### What does this PR do?
npm:lerna:release takes package names (that match package.json) and not paths (packages/foo)

### What issues does this PR fix or reference?
@W-9422476@

This fix **should** produce a signed npm package even without the other signing changes in W-9422476